### PR TITLE
feat: add Gradle task to skip UI tests

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -5,3 +5,4 @@
 - Server-only code must reside in the `server` module.
 
 Before commit please run `./gradlew ktlintFormat`
+To verify changes run `./gradlew checkAgentsEnvironment`

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -21,3 +21,17 @@ allprojects {
 		}
 	}
 }
+
+tasks.register("checkAgentsEnvironment") {
+	group = "verification"
+	description = "Runs all tests that are expected to pass in the agent environment"
+	dependsOn(
+		":composeApp:jvmNoUiTest",
+		":composeApp:testDebugUnitTest",
+		":composeApp:testReleaseUnitTest",
+		":shared:jvmTest",
+		":shared:testDebugUnitTest",
+		":shared:testReleaseUnitTest",
+		":server:test",
+	)
+}

--- a/composeApp/build.gradle.kts
+++ b/composeApp/build.gradle.kts
@@ -1,3 +1,4 @@
+import org.gradle.api.tasks.testing.Test
 import org.jetbrains.compose.ExperimentalComposeLibrary
 import org.jetbrains.compose.desktop.application.dsl.TargetFormat
 import org.jetbrains.kotlin.gradle.ExperimentalKotlinGradlePluginApi
@@ -65,6 +66,18 @@ kotlin {
 			implementation(libs.logback)
 			implementation(libs.mokkery.runtime)
 		}
+	}
+}
+
+val jvmTest by tasks.existing(Test::class)
+
+tasks.register<Test>("jvmNoUiTest") {
+	group = "verification"
+	description = "Runs JVM tests excluding UI tests"
+	testClassesDirs = jvmTest.get().testClassesDirs
+	classpath = jvmTest.get().classpath
+	useJUnit {
+		excludeCategories("de.lehrbaum.voiry.UiTest")
 	}
 }
 

--- a/composeApp/src/jvmTest/kotlin/de/lehrbaum/voiry/UiTest.kt
+++ b/composeApp/src/jvmTest/kotlin/de/lehrbaum/voiry/UiTest.kt
@@ -1,0 +1,3 @@
+package de.lehrbaum.voiry
+
+interface UiTest

--- a/composeApp/src/jvmTest/kotlin/de/lehrbaum/voiry/ui/MainScreenTest.kt
+++ b/composeApp/src/jvmTest/kotlin/de/lehrbaum/voiry/ui/MainScreenTest.kt
@@ -9,6 +9,7 @@ import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick
 import androidx.compose.ui.test.performTextInput
 import androidx.compose.ui.test.runComposeUiTest
+import de.lehrbaum.voiry.UiTest
 import de.lehrbaum.voiry.audio.Recorder
 import de.lehrbaum.voiry.recordings.Recording
 import de.lehrbaum.voiry.recordings.RecordingRepository
@@ -18,8 +19,10 @@ import dev.mokkery.mock
 import kotlinx.io.Buffer
 import kotlinx.io.writeString
 import org.junit.Test
+import org.junit.experimental.categories.Category
 
 @OptIn(ExperimentalTestApi::class)
+@Category(UiTest::class)
 class MainScreenTest {
 	@Test
 	fun displays_seeded_recordings_and_title_and_hides_fab_when_unavailable() =

--- a/env_setup.sh
+++ b/env_setup.sh
@@ -10,4 +10,5 @@ export PATH="$ANDROID_SDK_ROOT/cmdline-tools/latest/bin:$ANDROID_SDK_ROOT/platfo
 /bin/bash -c "yes | sdkmanager --licenses"
 sdkmanager "platform-tools" "platforms;android-35" "build-tools;35.0.0"
 cd $WORKSPACE_DIR
+printf "sdk.dir=%s\n" "$ANDROID_SDK_ROOT" > local.properties
 ./gradlew :composeApp:compileDebugSources


### PR DESCRIPTION
## Summary
- add marker interface to tag UI tests
- annotate MainScreenTest with UiTest category
- register `jvmNoUiTest` task to exclude UI tests
- add `checkAgentsEnvironment` task running server, shared, and Android JVM unit tests
- document new verification task in AGENTS instructions
- generate `local.properties` in `env_setup.sh` pointing to installed Android SDK

## Testing
- `./gradlew ktlintFormat`
- `./gradlew checkAgentsEnvironment --rerun-tasks`
- `./gradlew :server:test --rerun-tasks`
- `./gradlew :shared:jvmTest --rerun-tasks`
- `./gradlew :composeApp:jvmNoUiTest --rerun-tasks`
- `./gradlew :composeApp:testDebugUnitTest --rerun-tasks`
- `./gradlew :shared:testDebugUnitTest --rerun-tasks`
- `./gradlew :composeApp:testReleaseUnitTest --rerun-tasks`
- `./gradlew :shared:testReleaseUnitTest --rerun-tasks`
- `./gradlew :composeApp:jvmTest --rerun-tasks` *(fails: UnsatisfiedLinkError in MainScreenTest)*
- `./gradlew :composeApp:connectedDebugAndroidTest --rerun-tasks` *(fails: no connected Android devices)*

------
https://chatgpt.com/codex/tasks/task_e_68b09996adc8833282183c7f46fc1101