### PR TITLE
Run whisper transcriber on IO dispatcher

### DIFF
--- a/composeApp/build.gradle.kts
+++ b/composeApp/build.gradle.kts
@@ -10,6 +10,7 @@ plugins {
 	alias(libs.plugins.composeMultiplatform)
 	alias(libs.plugins.composeCompiler)
 	alias(libs.plugins.composeHotReload)
+	alias(libs.plugins.kotlinSerialization)
 	alias(libs.plugins.mokkery)
 }
 
@@ -40,6 +41,7 @@ kotlin {
 			implementation(libs.androidx.lifecycle.viewmodelCompose)
 			implementation(libs.androidx.lifecycle.runtimeCompose)
 			implementation(libs.kotlinx.io.core)
+			implementation(libs.kotlinx.serializationJson)
 			implementation(libs.ktor.clientCore)
 			implementation(libs.ktor.clientContentNegotiation)
 			implementation(libs.ktor.serializationKotlinxJson)

--- a/composeApp/src/commonMain/kotlin/de/lehrbaum/voiry/audio/Transcriber.kt
+++ b/composeApp/src/commonMain/kotlin/de/lehrbaum/voiry/audio/Transcriber.kt
@@ -1,0 +1,12 @@
+package de.lehrbaum.voiry.audio
+
+import kotlinx.io.Buffer
+
+/** Abstraction for turning audio into text. */
+interface Transcriber {
+	/**
+	 * Transcribes the given [buffer] and returns plain text.
+	 * Implementations may suspend while invoking platform services.
+	 */
+	suspend fun transcribe(buffer: Buffer): String
+}

--- a/composeApp/src/jvmMain/kotlin/de/lehrbaum/voiry/audio/WhisperCliTranscriber.kt
+++ b/composeApp/src/jvmMain/kotlin/de/lehrbaum/voiry/audio/WhisperCliTranscriber.kt
@@ -1,0 +1,53 @@
+package de.lehrbaum.voiry.audio
+
+import java.io.File
+import kotlin.io.path.createTempFile
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+import kotlinx.io.Buffer
+import kotlinx.io.readByteArray
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.json.Json
+
+/** Desktop transcriber backed by the `whisper-cli` executable. */
+class WhisperCliTranscriber(
+	private val modelPath: String = "whisper-models/ggml-large-v3-turbo.bin",
+	private val processRunner: (List<String>) -> Int = { command ->
+		ProcessBuilder(command).start().waitFor()
+	},
+) : Transcriber {
+	override suspend fun transcribe(buffer: Buffer): String =
+		withContext(Dispatchers.IO) {
+			val tmp = createTempFile(prefix = "voice-diary", suffix = ".wav").toFile()
+			val jsonFile = File(tmp.absolutePath + ".json")
+			try {
+				tmp.writeBytes(buffer.readByteArray())
+
+				val command = listOf(
+					"whisper-cli",
+					"--model",
+					modelPath,
+					"--file",
+					tmp.absolutePath,
+					"--output-json",
+				)
+				val exit = processRunner(command)
+				if (exit != 0) throw RuntimeException("whisper-cli failed with exit code $exit")
+
+				if (!jsonFile.exists()) throw RuntimeException("JSON output file not found: ${jsonFile.absolutePath}")
+
+				val json = Json { ignoreUnknownKeys = true }
+				val result = json.decodeFromString<WhisperResult>(jsonFile.readText())
+				result.transcription.joinToString(" ") { it.text.trim() }
+			} finally {
+				tmp.delete()
+				jsonFile.delete()
+			}
+		}
+
+	@Serializable
+	private data class WhisperResult(val transcription: List<Segment>)
+
+	@Serializable
+	private data class Segment(val text: String)
+}


### PR DESCRIPTION
## Summary
- run desktop Whisper CLI transcription on Dispatchers.IO and clean up temp files reliably
- remove RecordingRow composable and related test pending new UI integration
- drop temporary DesktopRecordingRepository and its unit test

## Testing
- `./gradlew ktlintFormat`
- `./gradlew checkAgentsEnvironment`


------
https://chatgpt.com/codex/tasks/task_e_68b0757e8ba883329f10b61cfbfb1b91