### PR TITLE
Add platform-aware whisper availability check

### DIFF
--- a/composeApp/src/androidMain/kotlin/de/lehrbaum/voiry/audio/WhisperAvailability.android.kt
+++ b/composeApp/src/androidMain/kotlin/de/lehrbaum/voiry/audio/WhisperAvailability.android.kt
@@ -1,0 +1,3 @@
+package de.lehrbaum.voiry.audio
+
+actual fun isWhisperAvailable(): Boolean = false

--- a/composeApp/src/commonMain/kotlin/de/lehrbaum/voiry/audio/WhisperAvailability.kt
+++ b/composeApp/src/commonMain/kotlin/de/lehrbaum/voiry/audio/WhisperAvailability.kt
@@ -1,0 +1,3 @@
+package de.lehrbaum.voiry.audio
+
+expect fun isWhisperAvailable(): Boolean

--- a/composeApp/src/jvmMain/kotlin/de/lehrbaum/voiry/audio/WhisperAvailability.jvm.kt
+++ b/composeApp/src/jvmMain/kotlin/de/lehrbaum/voiry/audio/WhisperAvailability.jvm.kt
@@ -1,0 +1,17 @@
+package de.lehrbaum.voiry.audio
+
+import java.io.IOException
+
+actual fun isWhisperAvailable(): Boolean =
+	try {
+		ProcessBuilder("whisper-cli", "--help")
+			.redirectErrorStream(true)
+			.start()
+			.also {
+				it.waitFor()
+				it.destroy()
+			}
+		true
+	} catch (e: IOException) {
+		false
+	}


### PR DESCRIPTION
## Summary
- expose `isWhisperAvailable` in common code
- implement desktop check that runs `whisper-cli --help`
- return `false` on Android

## Testing
- `./gradlew ktlintFormat`
- `./gradlew checkAgentsEnvironment`


------
https://chatgpt.com/codex/tasks/task_e_68b158f9dec083329b980bf119185b8d