### PR TITLE
Add platform transcriber integration

### DIFF
--- a/composeApp/src/androidMain/kotlin/de/lehrbaum/voiry/audio/WhisperAvailability.android.kt
+++ b/composeApp/src/androidMain/kotlin/de/lehrbaum/voiry/audio/WhisperAvailability.android.kt
@@ -1,3 +1,3 @@
 package de.lehrbaum.voiry.audio
 
-actual fun isWhisperAvailable(): Boolean = false
+actual suspend fun isWhisperAvailable(): Boolean = false

--- a/composeApp/src/commonMain/kotlin/de/lehrbaum/voiry/audio/WhisperAvailability.kt
+++ b/composeApp/src/commonMain/kotlin/de/lehrbaum/voiry/audio/WhisperAvailability.kt
@@ -1,3 +1,3 @@
 package de.lehrbaum.voiry.audio
 
-expect fun isWhisperAvailable(): Boolean
+expect suspend fun isWhisperAvailable(): Boolean

--- a/composeApp/src/commonMain/kotlin/de/lehrbaum/voiry/ui/MainScreen.kt
+++ b/composeApp/src/commonMain/kotlin/de/lehrbaum/voiry/ui/MainScreen.kt
@@ -26,6 +26,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.produceState
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
@@ -66,7 +67,9 @@ fun MainScreen(
 	var isRecording by remember { mutableStateOf(false) }
 	var pendingRecording by remember { mutableStateOf<Buffer?>(null) }
 	var pendingTitle by remember { mutableStateOf("") }
-	val canTranscribe = remember(transcriber) { transcriber != null && isWhisperAvailable() }
+	val canTranscribe by produceState(initialValue = false, transcriber) {
+		value = transcriber != null && isWhisperAvailable()
+	}
 
 	DisposableEffect(recorder) {
 		onDispose {

--- a/composeApp/src/jvmMain/kotlin/de/lehrbaum/voiry/audio/WhisperAvailability.jvm.kt
+++ b/composeApp/src/jvmMain/kotlin/de/lehrbaum/voiry/audio/WhisperAvailability.jvm.kt
@@ -1,17 +1,21 @@
 package de.lehrbaum.voiry.audio
 
 import java.io.IOException
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
 
-actual fun isWhisperAvailable(): Boolean =
-	try {
-		ProcessBuilder("whisper-cli", "--help")
-			.redirectErrorStream(true)
-			.start()
-			.also {
-				it.waitFor()
-				it.destroy()
-			}
-		true
-	} catch (e: IOException) {
-		false
+actual suspend fun isWhisperAvailable(): Boolean =
+	withContext(Dispatchers.IO) {
+		try {
+			ProcessBuilder("whisper-cli", "--help")
+				.redirectErrorStream(true)
+				.start()
+				.also {
+					it.waitFor()
+					it.destroy()
+				}
+			true
+		} catch (e: IOException) {
+			false
+		}
 	}


### PR DESCRIPTION
## Summary
- expose `platformTranscriber` expect and platform actuals
- integrate optional transcriber into `MainScreen` and `EntryRow`
- wire up audio transcription when Whisper is available
- check Whisper CLI availability asynchronously on IO dispatcher inside `isWhisperAvailable`

## Testing
- `./gradlew ktlintFormat`
- `./gradlew checkAgentsEnvironment`


------
https://chatgpt.com/codex/tasks/task_e_68b1e67ee9348332b2a00b4ef9937b49