### PR TITLE
Introduce MainViewModel for diary operations

### DIFF
--- a/composeApp/src/commonMain/kotlin/de/lehrbaum/voiry/ui/EntryDetailScreen.kt
+++ b/composeApp/src/commonMain/kotlin/de/lehrbaum/voiry/ui/EntryDetailScreen.kt
@@ -64,7 +64,9 @@ fun EntryDetailScreen(
 
 	DisposableEffect(player) {
 		onDispose {
-			player.close()
+			if (player !== platformPlayer) {
+				player.close()
+			}
 		}
 	}
 


### PR DESCRIPTION
## Summary
- add MainViewModel to manage diary entries, recording, and transcription
- refactor MainScreen to consume MainViewModel state and intents
- avoid closing shared player on entry detail screen disposal

## Testing
- `./gradlew ktlintFormat`
- `./gradlew checkAgentsEnvironment`


------
https://chatgpt.com/codex/tasks/task_e_68b298ff69d48332ab0559a94da88e8c