### PR TITLE
Annotate core interfaces as Stable

### DIFF
--- a/composeApp/src/commonMain/kotlin/de/lehrbaum/voiry/api/v1/DiaryClient.kt
+++ b/composeApp/src/commonMain/kotlin/de/lehrbaum/voiry/api/v1/DiaryClient.kt
@@ -1,5 +1,6 @@
 package de.lehrbaum.voiry.api.v1
 
+import androidx.compose.runtime.Stable
 import io.github.aakira.napier.Napier
 import io.ktor.client.HttpClient
 import io.ktor.client.call.body
@@ -46,6 +47,7 @@ import kotlinx.serialization.json.Json
  *
  * Uses Server-Sent Events to keep [entries] updated.
  */
+@Stable
 @ExperimentalUuidApi
 @ExperimentalTime
 open class DiaryClient(

--- a/composeApp/src/commonMain/kotlin/de/lehrbaum/voiry/audio/Recorder.kt
+++ b/composeApp/src/commonMain/kotlin/de/lehrbaum/voiry/audio/Recorder.kt
@@ -1,7 +1,9 @@
 package de.lehrbaum.voiry.audio
 
+import androidx.compose.runtime.Stable
 import kotlinx.io.Buffer
 
+@Stable
 interface Recorder {
 	val isAvailable: Boolean
 

--- a/composeApp/src/commonMain/kotlin/de/lehrbaum/voiry/audio/Transcriber.kt
+++ b/composeApp/src/commonMain/kotlin/de/lehrbaum/voiry/audio/Transcriber.kt
@@ -1,8 +1,10 @@
 package de.lehrbaum.voiry.audio
 
+import androidx.compose.runtime.Stable
 import kotlinx.io.Buffer
 
 /** Abstraction for turning audio into text. */
+@Stable
 interface Transcriber {
 	/**
 	 * Transcribes the given [buffer] and returns plain text.


### PR DESCRIPTION
## Summary
- mark DiaryClient as Stable to inform Compose
- declare Recorder and Transcriber interfaces Stable

## Testing
- `./gradlew ktlintFormat`
- `./gradlew checkAgentsEnvironment`


------
https://chatgpt.com/codex/tasks/task_e_68b2ccb28b448332ba2b5447b4a20d2f