### PR TITLE
Expose targeted entry flow and use in detail screen

### DIFF
--- a/composeApp/src/commonMain/kotlin/de/lehrbaum/voiry/api/v1/DiaryClient.kt
+++ b/composeApp/src/commonMain/kotlin/de/lehrbaum/voiry/api/v1/DiaryClient.kt
@@ -33,9 +33,11 @@ import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.cancel
 import kotlinx.coroutines.currentCoroutineContext
 import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.flow
+import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.runningFold
 import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.isActive
@@ -82,6 +84,8 @@ open class DiaryClient(
 		}
 	}.runningFold(emptyList<VoiceDiaryEntry>()) { list, event -> applyEvent(list, event) }
 		.stateIn(scope, SharingStarted.WhileSubscribed(), emptyList())
+
+	open fun entryFlow(id: Uuid): Flow<VoiceDiaryEntry?> = entries.map { list -> list.firstOrNull { it.id == id } }
 
 	override fun close() = scope.cancel()
 

--- a/composeApp/src/commonMain/kotlin/de/lehrbaum/voiry/ui/EntryDetailScreen.kt
+++ b/composeApp/src/commonMain/kotlin/de/lehrbaum/voiry/ui/EntryDetailScreen.kt
@@ -47,8 +47,8 @@ fun EntryDetailScreen(
 	transcriber: Transcriber? = platformTranscriber,
 ) {
 	val scope = rememberCoroutineScope()
-	val entries by diaryClient.entries.collectAsStateWithLifecycle()
-	val entry = entries.firstOrNull { it.id == entryId } ?: return
+	val entryState by diaryClient.entryFlow(entryId).collectAsStateWithLifecycle(initialValue = null)
+	val entry = entryState ?: return
 	var audio by remember { mutableStateOf<ByteArray?>(null) }
 	var isPlaying by remember { mutableStateOf(false) }
 	var error by remember { mutableStateOf<String?>(null) }


### PR DESCRIPTION
## Summary
- add DiaryClient.entryFlow to stream a single entry by id
- collect entry-specific flow in EntryDetailScreen

## Testing
- `./gradlew --no-daemon --console=plain ktlintFormat`
- `./gradlew --no-daemon --console=plain checkAgentsEnvironment`


------
https://chatgpt.com/codex/tasks/task_e_68b2cca4d61083329052c6e1183d3600