### PR TITLE
Integrate audio playback with basic-sound

### DIFF
--- a/composeApp/build.gradle.kts
+++ b/composeApp/build.gradle.kts
@@ -47,6 +47,7 @@ kotlin {
 			implementation(libs.ktor.serializationKotlinxJson)
 			implementation(libs.ktor.clientCio)
 			api(libs.napier)
+			implementation(libs.lexilabs.basic.sound)
 		}
 		commonTest.dependencies {
 			implementation(libs.kotlin.test)

--- a/composeApp/src/androidMain/kotlin/de/lehrbaum/voiry/audio/PlatformPlayer.android.kt
+++ b/composeApp/src/androidMain/kotlin/de/lehrbaum/voiry/audio/PlatformPlayer.android.kt
@@ -17,7 +17,10 @@ actual val platformPlayer: Player = object : Player {
 		val file = File.createTempFile("entry", ".wav")
 		file.writeBytes(audio)
 		tempFile = file
-		this.audio = Audio(file.absolutePath, true)
+		this.audio = Audio(file.absolutePath).also {
+			it.load()
+			it.play()
+		}
 	}
 
 	override fun stop() {

--- a/composeApp/src/androidMain/kotlin/de/lehrbaum/voiry/audio/PlatformPlayer.android.kt
+++ b/composeApp/src/androidMain/kotlin/de/lehrbaum/voiry/audio/PlatformPlayer.android.kt
@@ -1,14 +1,34 @@
+@file:OptIn(ExperimentalBasicSound::class)
+
 package de.lehrbaum.voiry.audio
+
+import app.lexilabs.basic.sound.Audio
+import app.lexilabs.basic.sound.ExperimentalBasicSound
+import java.io.File
 
 actual val platformPlayer: Player = object : Player {
 	override val isAvailable: Boolean = true
 
+	private var audio: Audio? = null
+	private var tempFile: File? = null
+
 	override fun play(audio: ByteArray) {
+		stop()
+		val file = File.createTempFile("entry", ".wav")
+		file.writeBytes(audio)
+		tempFile = file
+		this.audio = Audio(file.absolutePath, true)
 	}
 
 	override fun stop() {
+		audio?.stop()
+		audio?.release()
+		audio = null
+		tempFile?.delete()
+		tempFile = null
 	}
 
 	override fun close() {
+		stop()
 	}
 }

--- a/composeApp/src/jvmMain/kotlin/de/lehrbaum/voiry/audio/PlatformPlayer.jvm.kt
+++ b/composeApp/src/jvmMain/kotlin/de/lehrbaum/voiry/audio/PlatformPlayer.jvm.kt
@@ -17,7 +17,10 @@ actual val platformPlayer: Player = object : Player {
 		val file = File.createTempFile("entry", ".wav")
 		file.writeBytes(audio)
 		tempFile = file
-		this.audio = Audio(file.absolutePath, true)
+		this.audio = Audio(file.absolutePath).also {
+			it.load()
+			it.play()
+		}
 	}
 
 	override fun stop() {

--- a/composeApp/src/jvmMain/kotlin/de/lehrbaum/voiry/audio/PlatformPlayer.jvm.kt
+++ b/composeApp/src/jvmMain/kotlin/de/lehrbaum/voiry/audio/PlatformPlayer.jvm.kt
@@ -1,14 +1,34 @@
+@file:OptIn(ExperimentalBasicSound::class)
+
 package de.lehrbaum.voiry.audio
+
+import app.lexilabs.basic.sound.Audio
+import app.lexilabs.basic.sound.ExperimentalBasicSound
+import java.io.File
 
 actual val platformPlayer: Player = object : Player {
 	override val isAvailable: Boolean = true
 
+	private var audio: Audio? = null
+	private var tempFile: File? = null
+
 	override fun play(audio: ByteArray) {
+		stop()
+		val file = File.createTempFile("entry", ".wav")
+		file.writeBytes(audio)
+		tempFile = file
+		this.audio = Audio(file.absolutePath, true)
 	}
 
 	override fun stop() {
+		audio?.stop()
+		audio?.release()
+		audio = null
+		tempFile?.delete()
+		tempFile = null
 	}
 
 	override fun close() {
+		stop()
 	}
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -20,6 +20,7 @@ kotlinx-serialization = "1.9.0"
 exposed = "0.61.0"
 sqlite = "3.50.3.0"
 appdirs = "2.0.0"
+lexilabs-basic = "+"
 
 [libraries]
 kotlin-test = { module = "org.jetbrains.kotlin:kotlin-test", version.ref = "kotlin" }
@@ -48,6 +49,7 @@ exposed-core = { module = "org.jetbrains.exposed:exposed-core", version.ref = "e
 exposed-jdbc = { module = "org.jetbrains.exposed:exposed-jdbc", version.ref = "exposed" }
 sqlite = { module = "org.xerial:sqlite-jdbc", version.ref = "sqlite" }
 appdirs = { module = "ca.gosyer:kotlin-multiplatform-appdirs", version.ref = "appdirs" }
+lexilabs-basic-sound = { module = "app.lexilabs.basic:basic-sound", version.ref = "lexilabs-basic" }
 
 [plugins]
 androidApplication = { id = "com.android.application", version.ref = "agp" }


### PR DESCRIPTION
## Summary
- add basic-sound dependency for Kotlin Multiplatform
- implement platform audio players using basic-sound

## Testing
- `./gradlew ktlintFormat`
- `./gradlew checkAgentsEnvironment`


------
https://chatgpt.com/codex/tasks/task_e_68b3509390ac833289ac303b15f3032f