### PR TITLE
Show friendly transcription status

### DIFF
--- a/composeApp/src/commonMain/kotlin/de/lehrbaum/voiry/ui/EntryDetailScreen.kt
+++ b/composeApp/src/commonMain/kotlin/de/lehrbaum/voiry/ui/EntryDetailScreen.kt
@@ -86,7 +86,7 @@ fun EntryDetailScreen(
 			verticalArrangement = Arrangement.spacedBy(12.dp),
 		) {
 			Text("Recorded at: ${entry.recordedAt}")
-			Text(entry.transcriptionText ?: entry.transcriptionStatus.name)
+			Text(entry.transcriptionText ?: entry.transcriptionStatus.displayName())
 			audio?.let { data ->
 				TextButton(
 					onClick = {

--- a/composeApp/src/commonMain/kotlin/de/lehrbaum/voiry/ui/MainScreen.kt
+++ b/composeApp/src/commonMain/kotlin/de/lehrbaum/voiry/ui/MainScreen.kt
@@ -149,7 +149,7 @@ private fun EntryRow(
 		modifier = Modifier.fillMaxWidth().clickable { onClick() },
 		headlineContent = { Text(entry.title) },
 		supportingContent = {
-			Text(entry.transcriptionText ?: entry.transcriptionStatus.name)
+			Text(entry.transcriptionText ?: entry.transcriptionStatus.displayName())
 		},
 		trailingContent = {
 			Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {

--- a/composeApp/src/commonMain/kotlin/de/lehrbaum/voiry/ui/TranscriptionStatusExtensions.kt
+++ b/composeApp/src/commonMain/kotlin/de/lehrbaum/voiry/ui/TranscriptionStatusExtensions.kt
@@ -1,0 +1,11 @@
+package de.lehrbaum.voiry.ui
+
+import de.lehrbaum.voiry.api.v1.TranscriptionStatus
+
+fun TranscriptionStatus.displayName(): String =
+	when (this) {
+		TranscriptionStatus.NONE -> "Not yet transcribed"
+		TranscriptionStatus.IN_PROGRESS -> "Transcribing"
+		TranscriptionStatus.DONE -> "Transcribed"
+		TranscriptionStatus.FAILED -> "Transcription failed"
+	}

--- a/composeApp/src/jvmTest/kotlin/de/lehrbaum/voiry/ui/EntryDetailScreenTest.kt
+++ b/composeApp/src/jvmTest/kotlin/de/lehrbaum/voiry/ui/EntryDetailScreenTest.kt
@@ -115,6 +115,40 @@ class EntryDetailScreenTest {
 			assert(backCalled)
 			assert(client.entries.value.isEmpty())
 		}
+
+	@Test
+	fun displays_placeholder_when_no_transcription() =
+		runComposeUiTest {
+			val entry = VoiceDiaryEntry(
+				id = Uuid.random(),
+				title = "Recording 1",
+				recordedAt = Clock.System.now(),
+				duration = Duration.ZERO,
+				transcriptionText = null,
+				transcriptionStatus = TranscriptionStatus.NONE,
+			)
+			val client = EntryFakeDiaryClient(entry)
+			val player = mock<Player>(mode = MockMode.autoUnit)
+			every { player.isAvailable } returns true
+
+			setContent {
+				CompositionLocalProvider(LocalLifecycleOwner provides EntryFakeLifecycleOwner()) {
+					MaterialTheme {
+						EntryDetailScreen(
+							diaryClient = client,
+							entryId = entry.id,
+							onBack = {},
+							player = player,
+							transcriber = null,
+						)
+					}
+				}
+			}
+
+			waitForIdle()
+
+			onNodeWithText("Not yet transcribed", substring = false).assertIsDisplayed()
+		}
 }
 
 @OptIn(ExperimentalUuidApi::class, ExperimentalTime::class)

--- a/composeApp/src/jvmTest/kotlin/de/lehrbaum/voiry/ui/MainScreenTest.kt
+++ b/composeApp/src/jvmTest/kotlin/de/lehrbaum/voiry/ui/MainScreenTest.kt
@@ -143,6 +143,38 @@ class MainScreenTest {
 			waitForIdle()
 			onAllNodesWithText("Recording 1", substring = false).assertCountEquals(0)
 		}
+
+	@Test
+	fun shows_placeholder_when_transcription_missing() =
+		runComposeUiTest {
+			val entry = VoiceDiaryEntry(
+				id = Uuid.random(),
+				title = "Recording 1",
+				recordedAt = Clock.System.now(),
+				duration = Duration.ZERO,
+				transcriptionText = null,
+				transcriptionStatus = TranscriptionStatus.NONE,
+			)
+			val client = FakeDiaryClient(initial = listOf(entry))
+			val recorder = mock<Recorder>()
+			every { recorder.isAvailable } returns false
+
+			setContent {
+				CompositionLocalProvider(
+					LocalLifecycleOwner provides FakeLifecycleOwner(),
+					LocalViewModelStoreOwner provides FakeViewModelStoreOwner(),
+				) {
+					MaterialTheme {
+						MainScreen(diaryClient = client, recorder, onEntryClick = { })
+					}
+				}
+			}
+
+			waitForIdle()
+
+			onNodeWithText("Recording 1", substring = false).assertIsDisplayed()
+			onNodeWithText("Not yet transcribed", substring = false).assertIsDisplayed()
+		}
 }
 
 @OptIn(ExperimentalTime::class, ExperimentalUuidApi::class)


### PR DESCRIPTION
## Summary
- Add TranscriptionStatus.displayName extension for human readable labels
- Show displayName in MainScreen and EntryDetailScreen when no transcript text
- Test placeholder text when transcription is missing

## Testing
- `./gradlew ktlintFormat`
- `./gradlew checkAgentsEnvironment`


------
https://chatgpt.com/codex/tasks/task_e_68b35f6089a88332894dc8a78a466898