### PR TITLE
Log whisper-cli command

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -3,6 +3,7 @@
 - The `shared` module contains only code shared between client and server, such as data models.
 - Client-only logic must live in the `composeApp` module.
 - Server-only code must reside in the `server` module.
+- New features should include tests, but do not write tests for log output.
 
 Before commit please run `./gradlew ktlintFormat`
 To verify changes run `./gradlew checkAgentsEnvironment`

--- a/composeApp/src/jvmMain/kotlin/de/lehrbaum/voiry/audio/WhisperCliTranscriber.kt
+++ b/composeApp/src/jvmMain/kotlin/de/lehrbaum/voiry/audio/WhisperCliTranscriber.kt
@@ -1,5 +1,6 @@
 package de.lehrbaum.voiry.audio
 
+import io.github.aakira.napier.Napier
 import java.io.File
 import kotlin.io.path.createTempFile
 import kotlinx.coroutines.Dispatchers
@@ -8,6 +9,8 @@ import kotlinx.io.Buffer
 import kotlinx.io.readByteArray
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.json.Json
+
+private const val TAG = "WhisperCliTranscriber"
 
 /** Desktop transcriber backed by the `whisper-cli` executable. */
 class WhisperCliTranscriber(
@@ -31,8 +34,20 @@ class WhisperCliTranscriber(
 					tmp.absolutePath,
 					"--output-json",
 				)
+				Napier.d("Running: ${command.joinToString(" ")}", tag = TAG)
 				val exit = processRunner(command)
-				if (exit != 0) throw RuntimeException("whisper-cli failed with exit code $exit")
+				if (exit != 0) {
+					Napier.e(
+						"whisper-cli exited $exit: ${command.joinToString(" ")}",
+						tag = TAG,
+					)
+					throw RuntimeException("whisper-cli failed with exit code $exit")
+				} else {
+					Napier.i(
+						"whisper-cli exited $exit: ${command.joinToString(" ")}",
+						tag = TAG,
+					)
+				}
 
 				if (!jsonFile.exists()) throw RuntimeException("JSON output file not found: ${jsonFile.absolutePath}")
 


### PR DESCRIPTION
## Summary
- log whisper-cli invocations and their outcomes using Napier
- document that new features require tests but log output should not be tested
- restore WhisperCliTranscriber test verifying whisper-cli invocation and transcript parsing

## Testing
- `./gradlew ktlintFormat`
- `./gradlew checkAgentsEnvironment`
- `./gradlew :composeApp:jvmTest --tests "*WhisperCliTranscriberTest*"`


------
https://chatgpt.com/codex/tasks/task_e_68b35f6996b88332a372f178e849e2d9