### PR TITLE
Format entry timestamp

### DIFF
--- a/composeApp/build.gradle.kts
+++ b/composeApp/build.gradle.kts
@@ -48,6 +48,7 @@ kotlin {
 			implementation(libs.ktor.clientCio)
 			api(libs.napier)
 			implementation(libs.lexilabs.basic.sound)
+			implementation(libs.kotlinx.datetime)
 		}
 		commonTest.dependencies {
 			implementation(libs.kotlin.test)

--- a/composeApp/src/commonMain/kotlin/de/lehrbaum/voiry/ui/EntryDetailScreen.kt
+++ b/composeApp/src/commonMain/kotlin/de/lehrbaum/voiry/ui/EntryDetailScreen.kt
@@ -34,6 +34,8 @@ import kotlin.time.ExperimentalTime
 import kotlin.uuid.ExperimentalUuidApi
 import kotlin.uuid.Uuid
 import kotlinx.coroutines.launch
+import kotlinx.datetime.TimeZone
+import kotlinx.datetime.toLocalDateTime
 import kotlinx.io.Buffer
 import kotlinx.io.write
 
@@ -86,7 +88,25 @@ fun EntryDetailScreen(
 				.fillMaxSize(),
 			verticalArrangement = Arrangement.spacedBy(12.dp),
 		) {
-			Text("Recorded at: ${entry.recordedAt}")
+			val recordedAtFormatted =
+				kotlinx.datetime.Instant
+					.fromEpochMilliseconds(
+						entry.recordedAt.toEpochMilliseconds(),
+					).toLocalDateTime(TimeZone.currentSystemDefault())
+					.run {
+						buildString {
+							append(year)
+							append('-')
+							append(monthNumber.toString().padStart(2, '0'))
+							append('-')
+							append(dayOfMonth.toString().padStart(2, '0'))
+							append(' ')
+							append(hour.toString().padStart(2, '0'))
+							append(':')
+							append(minute.toString().padStart(2, '0'))
+						}
+					}
+			Text("Recorded at: $recordedAtFormatted")
 			Text(entry.transcriptionText ?: entry.transcriptionStatus.displayName())
 			audio?.let { data ->
 				TextButton(

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -21,6 +21,7 @@ exposed = "0.61.0"
 sqlite = "3.50.3.0"
 appdirs = "2.0.0"
 lexilabs-basic = "+"
+kotlinx-datetime = "0.6.0"
 
 [libraries]
 kotlin-test = { module = "org.jetbrains.kotlin:kotlin-test", version.ref = "kotlin" }
@@ -50,6 +51,7 @@ exposed-jdbc = { module = "org.jetbrains.exposed:exposed-jdbc", version.ref = "e
 sqlite = { module = "org.xerial:sqlite-jdbc", version.ref = "sqlite" }
 appdirs = { module = "ca.gosyer:kotlin-multiplatform-appdirs", version.ref = "appdirs" }
 lexilabs-basic-sound = { module = "app.lexilabs.basic:basic-sound", version.ref = "lexilabs-basic" }
+kotlinx-datetime = { module = "org.jetbrains.kotlinx:kotlinx-datetime", version.ref = "kotlinx-datetime" }
 
 [plugins]
 androidApplication = { id = "com.android.application", version.ref = "agp" }


### PR DESCRIPTION
## Summary
- Format entry timestamps in local time using kotlinx-datetime
- Add kotlinx-datetime dependency for time zone conversion

## Testing
- `./gradlew ktlintFormat`
- `./gradlew checkAgentsEnvironment`


------
https://chatgpt.com/codex/tasks/task_e_68b40b243adc8332bea2f20795720c13