### PR TITLE
Add Docker build and compose setup for server deployment

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,15 @@
+# --- build stage ---
+FROM gradle:8.5-jdk17 AS build
+WORKDIR /src
+COPY . .
+RUN ./gradlew :server:buildFatJar --no-daemon
+
+# --- runtime stage ---
+FROM eclipse-temurin:17-jre
+WORKDIR /app
+COPY --from=build /src/server/build/libs/*-all.jar app.jar
+ENV VOICE_DIARY_DB_PATH=/data
+VOLUME /data
+EXPOSE 8080
+ENTRYPOINT ["java","-jar","/app/app.jar"]
+

--- a/README.md
+++ b/README.md
@@ -15,3 +15,13 @@ This is a Kotlin Multiplatform project targeting Android, Desktop (JVM), Server.
   The most important subfolder is [commonMain](./shared/src/commonMain/kotlin). If preferred, you can add code to the platform-specific folders here too.
 
 Learn more about [Kotlin Multiplatform](https://www.jetbrains.com/help/kotlin-multiplatform-dev/get-started.html)…
+
+## Running the server with Docker
+
+Build and run the server in a container using Docker Compose:
+
+```bash
+docker compose up -d
+```
+
+The container stores its SQLite database and uploaded audio files in the `data/` directory at the root of the repository, mounted at `/data` inside the container.

--- a/data/.gitignore
+++ b/data/.gitignore
@@ -1,0 +1,2 @@
+*
+!.gitignore

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,7 +5,5 @@ services:
     ports:
       - "8080:8080"
     volumes:
-      - voice-diary-data:/data
-volumes:
-  voice-diary-data:
+      - ./data:/data
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,11 @@
+version: "3.9"
+services:
+  voice-diary:
+    build: .
+    ports:
+      - "8080:8080"
+    volumes:
+      - voice-diary-data:/data
+volumes:
+  voice-diary-data:
+


### PR DESCRIPTION
## Summary
- provide multi-stage Dockerfile building the server fat jar
- add docker-compose.yml to run the server with persistent volume

## Testing
- `./gradlew ktlintFormat`
- `./gradlew checkAgentsEnvironment`


------
https://chatgpt.com/codex/tasks/task_e_68b4566346648332a1f590aab36be1a7