### PR TITLE
Handle missing transcriber gracefully

### DIFF
--- a/composeApp/src/commonMain/kotlin/de/lehrbaum/voiry/ui/EntryDetailScreen.kt
+++ b/composeApp/src/commonMain/kotlin/de/lehrbaum/voiry/ui/EntryDetailScreen.kt
@@ -137,7 +137,13 @@ fun EntryDetailScreen(
 								scope.launch {
 									runCatching {
 										val buffer = Buffer().apply { write(data) }
-										val text = transcriber!!.transcribe(buffer)
+										val text =
+											transcriber?.transcribe(buffer)
+												?: run {
+													error =
+														"Transcriber unavailable"
+													return@launch
+												}
 										diaryClient.updateTranscription(
 											entry.id,
 											UpdateTranscriptionRequest(


### PR DESCRIPTION
## Summary
- Use safe call when transcribing audio to avoid NPE if transcriber is absent
- Show an error when transcriber is unavailable and skip transcription update

## Testing
- `./gradlew ktlintFormat`
- `./gradlew checkAgentsEnvironment`


------
https://chatgpt.com/codex/tasks/task_e_68b5c3065e8c83328495a07924e6ab5b