### PR TITLE
Log recorder closure errors

### DIFF
--- a/composeApp/src/commonMain/kotlin/de/lehrbaum/voiry/ui/MainViewModel.kt
+++ b/composeApp/src/commonMain/kotlin/de/lehrbaum/voiry/ui/MainViewModel.kt
@@ -12,6 +12,7 @@ import de.lehrbaum.voiry.audio.Transcriber
 import de.lehrbaum.voiry.audio.isWhisperAvailable
 import de.lehrbaum.voiry.audio.platformRecorder
 import de.lehrbaum.voiry.audio.platformTranscriber
+import io.github.aakira.napier.Napier
 import java.io.Closeable
 import kotlin.time.Clock
 import kotlin.time.Duration
@@ -54,6 +55,7 @@ class MainViewModel(
 
 	override fun close() {
 		runCatching { recorder.close() }
+			.onFailure { Napier.e("Recorder close failed", it) }
 	}
 
 	fun startRecording() {


### PR DESCRIPTION
## Summary
- Log recorder closing failures in MainViewModel using Napier

## Testing
- `./gradlew ktlintFormat`
- `./gradlew checkAgentsEnvironment`


------
https://chatgpt.com/codex/tasks/task_e_68b5c484ff1c83328ad7ad8d75d4e891