### PR TITLE
Use safe call for selected entry

### DIFF
--- a/composeApp/src/commonMain/kotlin/de/lehrbaum/voiry/App.kt
+++ b/composeApp/src/commonMain/kotlin/de/lehrbaum/voiry/App.kt
@@ -25,7 +25,8 @@ fun App(baseUrl: String = "http://localhost:8080", onRequestAudioPermission: (()
 		onDispose { diaryClient.close() }
 	}
 	MaterialTheme {
-		if (selectedEntryId == null) {
+		val entryId = selectedEntryId
+		if (entryId == null) {
 			MainScreen(
 				diaryClient = diaryClient,
 				onRequestAudioPermission = onRequestAudioPermission,
@@ -34,7 +35,7 @@ fun App(baseUrl: String = "http://localhost:8080", onRequestAudioPermission: (()
 		} else {
 			EntryDetailScreen(
 				diaryClient = diaryClient,
-				entryId = selectedEntryId!!,
+				entryId = entryId,
 				onBack = { selectedEntryId = null },
 			)
 		}


### PR DESCRIPTION
## Summary
- avoid non-null assertion by smart-casting selected entry ID to render either the detail or main screen

## Testing
- `./gradlew ktlintFormat`
- `./gradlew checkAgentsEnvironment`


------
https://chatgpt.com/codex/tasks/task_e_68b5c2f7ac088332b26382e39020b39e