### PR TITLE
feat: add stable ui entry type

### DIFF
--- a/composeApp/src/commonMain/kotlin/de/lehrbaum/voiry/ui/MainScreen.kt
+++ b/composeApp/src/commonMain/kotlin/de/lehrbaum/voiry/ui/MainScreen.kt
@@ -32,7 +32,6 @@ import androidx.compose.ui.unit.dp
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.lifecycle.viewmodel.compose.viewModel
 import de.lehrbaum.voiry.api.v1.DiaryClient
-import de.lehrbaum.voiry.api.v1.VoiceDiaryEntry
 import de.lehrbaum.voiry.audio.Recorder
 import de.lehrbaum.voiry.audio.Transcriber
 import de.lehrbaum.voiry.audio.platformRecorder
@@ -47,7 +46,7 @@ fun MainScreen(
 	recorder: Recorder = platformRecorder,
 	onRequestAudioPermission: (() -> Unit)? = null,
 	transcriber: Transcriber? = platformTranscriber,
-	onEntryClick: (VoiceDiaryEntry) -> Unit,
+	onEntryClick: (UiVoiceDiaryEntry) -> Unit,
 ) {
 	val viewModel = viewModel { MainViewModel(diaryClient, recorder, transcriber) }
 	val state by viewModel.uiState.collectAsStateWithLifecycle()
@@ -140,9 +139,9 @@ fun MainScreen(
 
 @Composable
 private fun EntryRow(
-	entry: VoiceDiaryEntry,
-	onDelete: (VoiceDiaryEntry) -> Unit,
-	onTranscribe: ((VoiceDiaryEntry) -> Unit)? = null,
+	entry: UiVoiceDiaryEntry,
+	onDelete: (UiVoiceDiaryEntry) -> Unit,
+	onTranscribe: ((UiVoiceDiaryEntry) -> Unit)? = null,
 	onClick: () -> Unit,
 ) {
 	ListItem(

--- a/composeApp/src/commonMain/kotlin/de/lehrbaum/voiry/ui/MainViewModel.kt
+++ b/composeApp/src/commonMain/kotlin/de/lehrbaum/voiry/ui/MainViewModel.kt
@@ -39,7 +39,7 @@ class MainViewModel(
 	init {
 		viewModelScope.launch {
 			diaryClient.entries.collect { entries ->
-				_uiState.update { it.copy(entries = entries) }
+				_uiState.update { it.copy(entries = entries.map { it.toUi() }) }
 			}
 		}
 		viewModelScope.launch {
@@ -113,14 +113,14 @@ class MainViewModel(
 		}
 	}
 
-	fun deleteEntry(entry: VoiceDiaryEntry) {
+	fun deleteEntry(entry: UiVoiceDiaryEntry) {
 		viewModelScope.launch {
 			runCatching { diaryClient.deleteEntry(entry.id) }
 				.onFailure { e -> _uiState.update { it.copy(error = e.message) } }
 		}
 	}
 
-	fun transcribe(entry: VoiceDiaryEntry) {
+	fun transcribe(entry: UiVoiceDiaryEntry) {
 		val transcriber = transcriber ?: return
 		viewModelScope.launch {
 			runCatching {
@@ -154,7 +154,7 @@ class MainViewModel(
 
 @OptIn(ExperimentalUuidApi::class)
 data class MainUiState(
-	val entries: List<VoiceDiaryEntry> = emptyList(),
+	val entries: List<UiVoiceDiaryEntry> = emptyList(),
 	val isRecording: Boolean = false,
 	val pendingRecording: Recording? = null,
 	val pendingTitle: String = "",

--- a/composeApp/src/commonMain/kotlin/de/lehrbaum/voiry/ui/UiVoiceDiaryEntry.kt
+++ b/composeApp/src/commonMain/kotlin/de/lehrbaum/voiry/ui/UiVoiceDiaryEntry.kt
@@ -1,0 +1,34 @@
+@file:OptIn(ExperimentalUuidApi::class, ExperimentalTime::class)
+
+package de.lehrbaum.voiry.ui
+
+import androidx.compose.runtime.Immutable
+import de.lehrbaum.voiry.api.v1.TranscriptionStatus
+import de.lehrbaum.voiry.api.v1.VoiceDiaryEntry
+import kotlin.time.Duration
+import kotlin.time.ExperimentalTime
+import kotlin.time.Instant
+import kotlin.uuid.ExperimentalUuidApi
+import kotlin.uuid.Uuid
+
+@Immutable
+data class UiVoiceDiaryEntry(
+	val id: Uuid,
+	val title: String,
+	val recordedAt: Instant,
+	val duration: Duration,
+	val transcriptionText: String?,
+	val transcriptionStatus: TranscriptionStatus,
+	val transcriptionUpdatedAt: Instant?,
+)
+
+fun VoiceDiaryEntry.toUi() =
+	UiVoiceDiaryEntry(
+		id = id,
+		title = title,
+		recordedAt = recordedAt,
+		duration = duration,
+		transcriptionText = transcriptionText,
+		transcriptionStatus = transcriptionStatus,
+		transcriptionUpdatedAt = transcriptionUpdatedAt,
+	)


### PR DESCRIPTION
## Summary
- add immutable UiVoiceDiaryEntry wrapper with mapper
- expose UiVoiceDiaryEntry list from MainViewModel
- update MainScreen composables to use UiVoiceDiaryEntry

## Testing
- `./gradlew ktlintFormat`
- `./gradlew checkAgentsEnvironment`


------
https://chatgpt.com/codex/tasks/task_e_68b5cef1059483328ffa8c40038d337a