### PR TITLE
Dispose multipart parts in file upload handler

### DIFF
--- a/server/src/main/kotlin/de/lehrbaum/voiry/Application.kt
+++ b/server/src/main/kotlin/de/lehrbaum/voiry/Application.kt
@@ -71,6 +71,7 @@ fun Application.module(service: DiaryService = runBlocking { DiaryServiceImpl.cr
 						}
 						else -> {}
 					}
+					part.dispose()
 				}
 				if (metadata == null || audio == null) {
 					call.respond(HttpStatusCode.BadRequest)


### PR DESCRIPTION
## Summary
- dispose multipart parts after processing to avoid resource leaks

## Testing
- `./gradlew ktlintFormat`
- `./gradlew checkAgentsEnvironment`


------
https://chatgpt.com/codex/tasks/task_e_68b5f95bbfe88332b84f898a4b3dcdc8