### PR TITLE
Remember navigation callbacks to avoid recompositions

### DIFF
--- a/composeApp/src/commonMain/kotlin/de/lehrbaum/voiry/App.kt
+++ b/composeApp/src/commonMain/kotlin/de/lehrbaum/voiry/App.kt
@@ -10,6 +10,7 @@ import androidx.compose.runtime.setValue
 import de.lehrbaum.voiry.api.v1.DiaryClient
 import de.lehrbaum.voiry.ui.EntryDetailScreen
 import de.lehrbaum.voiry.ui.MainScreen
+import de.lehrbaum.voiry.ui.UiVoiceDiaryEntry
 import kotlin.time.ExperimentalTime
 import kotlin.uuid.ExperimentalUuidApi
 import kotlin.uuid.Uuid
@@ -24,19 +25,25 @@ fun App(baseUrl: String = "http://localhost:8080", onRequestAudioPermission: (()
 	DisposableEffect(diaryClient) {
 		onDispose { diaryClient.close() }
 	}
+	val onEntryClick: (UiVoiceDiaryEntry) -> Unit = remember {
+		{ entry -> selectedEntryId = entry.id }
+	}
+	val onBack: () -> Unit = remember {
+		{ selectedEntryId = null }
+	}
 	MaterialTheme {
 		val entryId = selectedEntryId
 		if (entryId == null) {
 			MainScreen(
 				diaryClient = diaryClient,
 				onRequestAudioPermission = onRequestAudioPermission,
-				onEntryClick = { entry -> selectedEntryId = entry.id },
+				onEntryClick = onEntryClick,
 			)
 		} else {
 			EntryDetailScreen(
 				diaryClient = diaryClient,
 				entryId = entryId,
-				onBack = { selectedEntryId = null },
+				onBack = onBack,
 			)
 		}
 	}


### PR DESCRIPTION
## Summary
- remember navigation callbacks in `App` to keep lambda identity stable

## Testing
- `./gradlew ktlintFormat`
- `./gradlew checkAgentsEnvironment`


------
https://chatgpt.com/codex/tasks/task_e_68b5f9271e848332b0152bb0d6df9564