### PR TITLE
Enable Compose compiler reports

### DIFF
--- a/composeApp/build.gradle.kts
+++ b/composeApp/build.gradle.kts
@@ -112,6 +112,11 @@ android {
 	}
 }
 
+composeCompiler {
+	reportsDestination = layout.buildDirectory.dir("compose_compiler")
+	metricsDestination = layout.buildDirectory.dir("compose_compiler")
+}
+
 dependencies {
 	debugImplementation(compose.uiTooling)
 }


### PR DESCRIPTION
## Summary
- enable Compose Compiler metrics & report generation
- investigate report for unstable parameters in composables

## Testing
- `./gradlew --no-daemon --console=plain ktlintFormat`
- `./gradlew --no-daemon --console=plain :composeApp:compileDebugKotlin --rerun-tasks`
- `./gradlew --no-daemon --console=plain checkAgentsEnvironment`


------
https://chatgpt.com/codex/tasks/task_e_68b5fe711bfc8332a740e2134c483ac1