### PR TITLE
Use remembered lambdas for stable EntryRow buttons

### DIFF
--- a/composeApp/src/commonMain/kotlin/de/lehrbaum/voiry/ui/MainScreen.kt
+++ b/composeApp/src/commonMain/kotlin/de/lehrbaum/voiry/ui/MainScreen.kt
@@ -137,6 +137,7 @@ fun MainScreen(
 	}
 }
 
+@OptIn(ExperimentalUuidApi::class)
 @Composable
 private fun EntryRow(
 	entry: UiVoiceDiaryEntry,
@@ -144,6 +145,10 @@ private fun EntryRow(
 	onTranscribe: ((UiVoiceDiaryEntry) -> Unit)? = null,
 	onClick: () -> Unit,
 ) {
+	val onDeleteClick = remember(entry.id, onDelete) { { onDelete(entry) } }
+	val onTranscribeClick = remember(entry.id, onTranscribe) {
+		onTranscribe?.let { { it(entry) } }
+	}
 	ListItem(
 		modifier = Modifier.fillMaxWidth().clickable { onClick() },
 		headlineContent = { Text(entry.title) },
@@ -152,10 +157,10 @@ private fun EntryRow(
 		},
 		trailingContent = {
 			Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
-				if (onTranscribe != null) {
-					TextButton(onClick = { onTranscribe(entry) }) { Text("Transcribe") }
+				if (onTranscribeClick != null) {
+					TextButton(onClick = onTranscribeClick) { Text("Transcribe") }
 				}
-				TextButton(onClick = { onDelete(entry) }) { Text("Delete") }
+				TextButton(onClick = onDeleteClick) { Text("Delete") }
 			}
 		},
 	)


### PR DESCRIPTION
## Summary
- cache EntryRow delete and transcribe callbacks with remember to reduce recomposition
- remember transcribe callback even when absent to avoid lambda churn
- opt in to ExperimentalUuidApi for accessing entry IDs inside the row

## Testing
- `./gradlew ktlintFormat`
- `./gradlew checkAgentsEnvironment`


------
https://chatgpt.com/codex/tasks/task_e_68b5fe938e1483329c62e603ec540af5