### PR TITLE
Use remember for record button lambda

### DIFF
--- a/composeApp/src/commonMain/kotlin/de/lehrbaum/voiry/ui/MainScreen.kt
+++ b/composeApp/src/commonMain/kotlin/de/lehrbaum/voiry/ui/MainScreen.kt
@@ -50,14 +50,20 @@ fun MainScreen(
 ) {
 	val viewModel = viewModel { MainViewModel(diaryClient, recorder, transcriber) }
 	val state by viewModel.uiState.collectAsStateWithLifecycle()
+	val recordClick = remember(viewModel) {
+		{
+			val isRecording = viewModel.uiState.value.isRecording
+			if (!isRecording) viewModel.startRecording() else viewModel.stopRecording()
+		}
+	}
 
 	Scaffold(
 		topBar = { TopAppBar(title = { Text("Voice Diary") }) },
 		floatingActionButton = {
 			if (state.recorderAvailable) {
-				ExtendedFloatingActionButton(onClick = {
-					if (!state.isRecording) viewModel.startRecording() else viewModel.stopRecording()
-				}) { Text(if (state.isRecording) "Stop" else "Record") }
+				ExtendedFloatingActionButton(onClick = recordClick) {
+					Text(if (state.isRecording) "Stop" else "Record")
+				}
 			}
 		},
 	) { padding ->


### PR DESCRIPTION
## Summary
- remember record button lambda to avoid recreation
- read recording state lazily from the view model

## Testing
- `./gradlew ktlintFormat`
- `./gradlew checkAgentsEnvironment`


------
https://chatgpt.com/codex/tasks/task_e_68b5fe9414148332a1348eaa1f9c9b3f