### PR TITLE
Initialize shared transcriber at app startup

### DIFF
--- a/composeApp/src/commonMain/kotlin/de/lehrbaum/voiry/App.kt
+++ b/composeApp/src/commonMain/kotlin/de/lehrbaum/voiry/App.kt
@@ -3,11 +3,14 @@ package de.lehrbaum.voiry
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.DisposableEffect
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import de.lehrbaum.voiry.api.v1.DiaryClient
+import de.lehrbaum.voiry.audio.Transcriber
+import de.lehrbaum.voiry.audio.platformTranscriber
 import de.lehrbaum.voiry.ui.EntryDetailScreen
 import de.lehrbaum.voiry.ui.MainScreen
 import de.lehrbaum.voiry.ui.UiVoiceDiaryEntry
@@ -21,6 +24,8 @@ import org.jetbrains.compose.ui.tooling.preview.Preview
 @Preview
 fun App(baseUrl: String = "http://localhost:8080", onRequestAudioPermission: (() -> Unit)? = null) {
 	val diaryClient = remember { DiaryClient(baseUrl) }
+	val transcriber: Transcriber? = remember { platformTranscriber }
+	LaunchedEffect(transcriber) { transcriber?.initialize() }
 	var selectedEntryId by remember { mutableStateOf<Uuid?>(null) }
 	DisposableEffect(diaryClient) {
 		onDispose { diaryClient.close() }
@@ -37,6 +42,7 @@ fun App(baseUrl: String = "http://localhost:8080", onRequestAudioPermission: (()
 			MainScreen(
 				diaryClient = diaryClient,
 				onRequestAudioPermission = onRequestAudioPermission,
+				transcriber = transcriber,
 				onEntryClick = onEntryClick,
 			)
 		} else {
@@ -44,6 +50,7 @@ fun App(baseUrl: String = "http://localhost:8080", onRequestAudioPermission: (()
 				diaryClient = diaryClient,
 				entryId = entryId,
 				onBack = onBack,
+				transcriber = transcriber,
 			)
 		}
 	}

--- a/composeApp/src/commonMain/kotlin/de/lehrbaum/voiry/ui/EntryDetailScreen.kt
+++ b/composeApp/src/commonMain/kotlin/de/lehrbaum/voiry/ui/EntryDetailScreen.kt
@@ -27,7 +27,6 @@ import de.lehrbaum.voiry.api.v1.UpdateTranscriptionRequest
 import de.lehrbaum.voiry.audio.Player
 import de.lehrbaum.voiry.audio.Transcriber
 import de.lehrbaum.voiry.audio.platformPlayer
-import de.lehrbaum.voiry.audio.platformTranscriber
 import kotlin.time.Clock
 import kotlin.time.ExperimentalTime
 import kotlin.uuid.ExperimentalUuidApi
@@ -44,7 +43,7 @@ fun EntryDetailScreen(
 	entryId: Uuid,
 	onBack: () -> Unit,
 	player: Player = platformPlayer,
-	transcriber: Transcriber? = platformTranscriber,
+	transcriber: Transcriber?,
 ) {
 	val scope = rememberCoroutineScope()
 	val entryFlow = remember(entryId) { diaryClient.entryFlow(entryId) }

--- a/composeApp/src/commonMain/kotlin/de/lehrbaum/voiry/ui/MainScreen.kt
+++ b/composeApp/src/commonMain/kotlin/de/lehrbaum/voiry/ui/MainScreen.kt
@@ -35,7 +35,6 @@ import de.lehrbaum.voiry.api.v1.DiaryClient
 import de.lehrbaum.voiry.audio.Recorder
 import de.lehrbaum.voiry.audio.Transcriber
 import de.lehrbaum.voiry.audio.platformRecorder
-import de.lehrbaum.voiry.audio.platformTranscriber
 import kotlin.time.ExperimentalTime
 import kotlin.uuid.ExperimentalUuidApi
 
@@ -45,7 +44,7 @@ fun MainScreen(
 	diaryClient: DiaryClient,
 	recorder: Recorder = platformRecorder,
 	onRequestAudioPermission: (() -> Unit)? = null,
-	transcriber: Transcriber? = platformTranscriber,
+	transcriber: Transcriber?,
 	onEntryClick: (UiVoiceDiaryEntry) -> Unit,
 ) {
 	val viewModel = viewModel { MainViewModel(diaryClient, recorder, transcriber) }

--- a/composeApp/src/commonMain/kotlin/de/lehrbaum/voiry/ui/MainViewModel.kt
+++ b/composeApp/src/commonMain/kotlin/de/lehrbaum/voiry/ui/MainViewModel.kt
@@ -9,9 +9,7 @@ import de.lehrbaum.voiry.api.v1.UpdateTranscriptionRequest
 import de.lehrbaum.voiry.api.v1.VoiceDiaryEntry
 import de.lehrbaum.voiry.audio.Recorder
 import de.lehrbaum.voiry.audio.Transcriber
-import de.lehrbaum.voiry.audio.isWhisperAvailable
 import de.lehrbaum.voiry.audio.platformRecorder
-import de.lehrbaum.voiry.audio.platformTranscriber
 import io.github.aakira.napier.Napier
 import java.io.Closeable
 import kotlin.time.Clock
@@ -31,7 +29,7 @@ import kotlinx.io.readByteArray
 class MainViewModel(
 	private val diaryClient: DiaryClient,
 	private val recorder: Recorder = platformRecorder,
-	private val transcriber: Transcriber? = platformTranscriber,
+	private val transcriber: Transcriber?,
 ) : ViewModel(), Closeable {
 	private val _uiState = MutableStateFlow(MainUiState(recorderAvailable = recorder.isAvailable))
 	val uiState: StateFlow<MainUiState> = _uiState.asStateFlow()
@@ -40,11 +38,6 @@ class MainViewModel(
 		viewModelScope.launch {
 			diaryClient.entries.collect { entries ->
 				_uiState.update { it.copy(entries = entries.map { it.toUi() }) }
-			}
-		}
-		viewModelScope.launch {
-			if (transcriber != null && isWhisperAvailable()) {
-				transcriber.initialize()
 			}
 		}
 	}

--- a/composeApp/src/jvmTest/kotlin/de/lehrbaum/voiry/ui/MainScreenTest.kt
+++ b/composeApp/src/jvmTest/kotlin/de/lehrbaum/voiry/ui/MainScreenTest.kt
@@ -53,7 +53,12 @@ class MainScreenTest {
 					LocalViewModelStoreOwner provides FakeViewModelStoreOwner(),
 				) {
 					MaterialTheme {
-						MainScreen(diaryClient = client, recorder = unavailableRecorder, onEntryClick = { })
+						MainScreen(
+							diaryClient = client,
+							recorder = unavailableRecorder,
+							transcriber = null,
+							onEntryClick = { },
+						)
 					}
 				}
 			}
@@ -93,7 +98,12 @@ class MainScreenTest {
 					LocalViewModelStoreOwner provides FakeViewModelStoreOwner(),
 				) {
 					MaterialTheme {
-						MainScreen(diaryClient = client, recorder, onEntryClick = { })
+						MainScreen(
+							diaryClient = client,
+							recorder = recorder,
+							transcriber = null,
+							onEntryClick = { },
+						)
 					}
 				}
 			}
@@ -131,7 +141,12 @@ class MainScreenTest {
 					LocalViewModelStoreOwner provides FakeViewModelStoreOwner(),
 				) {
 					MaterialTheme {
-						MainScreen(diaryClient = client, recorder, onEntryClick = { })
+						MainScreen(
+							diaryClient = client,
+							recorder = recorder,
+							transcriber = null,
+							onEntryClick = { },
+						)
 					}
 				}
 			}
@@ -165,7 +180,12 @@ class MainScreenTest {
 					LocalViewModelStoreOwner provides FakeViewModelStoreOwner(),
 				) {
 					MaterialTheme {
-						MainScreen(diaryClient = client, recorder, onEntryClick = { })
+						MainScreen(
+							diaryClient = client,
+							recorder = recorder,
+							transcriber = null,
+							onEntryClick = { },
+						)
 					}
 				}
 			}


### PR DESCRIPTION
## Summary
- Remember a single Transcriber in App and initialize it on startup
- Pass the shared Transcriber to screens instead of creating new instances
- Remove Transcriber initialization from MainViewModel

## Testing
- `./gradlew ktlintFormat`
- `./gradlew checkAgentsEnvironment`


------
https://chatgpt.com/codex/tasks/task_e_68b8739a35e48332b7f35b270e01875e