### PR TITLE
Allow dismissing recorder unavailable banner

### DIFF
--- a/composeApp/src/commonMain/kotlin/de/lehrbaum/voiry/ui/MainScreen.kt
+++ b/composeApp/src/commonMain/kotlin/de/lehrbaum/voiry/ui/MainScreen.kt
@@ -71,8 +71,12 @@ fun MainScreen(
 				.padding(padding)
 				.fillMaxSize(),
 		) {
-			if (!state.recorderAvailable) {
-				InfoBanner("Audio recorder not available on this platform/device.")
+			if (!state.recorderAvailable && !state.recorderUnavailableDismissed) {
+				InfoBanner(
+					text = "Audio recorder not available on this platform/device.",
+					actionLabel = "Dismiss",
+					onAction = { viewModel.dismissRecorderUnavailable() },
+				)
 			}
 			if (state.error != null) {
 				val permissionRelated =

--- a/composeApp/src/commonMain/kotlin/de/lehrbaum/voiry/ui/MainViewModel.kt
+++ b/composeApp/src/commonMain/kotlin/de/lehrbaum/voiry/ui/MainViewModel.kt
@@ -82,6 +82,10 @@ class MainViewModel(
 		}
 	}
 
+	fun dismissRecorderUnavailable() {
+		_uiState.update { it.copy(recorderUnavailableDismissed = true) }
+	}
+
 	fun updatePendingTitle(title: String) {
 		_uiState.update { it.copy(pendingTitle = title) }
 	}
@@ -154,6 +158,7 @@ data class MainUiState(
 	val pendingTitle: String = "",
 	val error: String? = null,
 	val recorderAvailable: Boolean = true,
+	val recorderUnavailableDismissed: Boolean = false,
 )
 
 @Stable

--- a/composeApp/src/jvmTest/kotlin/de/lehrbaum/voiry/ui/MainScreenTest.kt
+++ b/composeApp/src/jvmTest/kotlin/de/lehrbaum/voiry/ui/MainScreenTest.kt
@@ -78,8 +78,11 @@ class MainScreenTest {
 
 			// FAB should be hidden when recorder is not available
 			onAllNodesWithText("Record", substring = false).assertCountEquals(0)
-			// Info banner is shown
+			// Info banner can be dismissed
 			onNodeWithText("Audio recorder not available on this platform/device.", substring = false).assertIsDisplayed()
+			onNodeWithText("Dismiss", substring = false).performClick()
+			waitForIdle()
+			onAllNodesWithText("Audio recorder not available on this platform/device.", substring = false).assertCountEquals(0)
 		}
 
 	@Test


### PR DESCRIPTION
## Summary
- Add view-model state and method to hide recorder-unavailable notices
- Show dismissible banner when no recorder is present
- Test dismissing the recorder-unavailable banner

## Testing
- `./gradlew ktlintFormat`
- `./gradlew checkAgentsEnvironment`
- ⚠️ `./gradlew composeApp:jvmTest` (fails: NoClassDefFoundError at NativeLibraries)


------
https://chatgpt.com/codex/tasks/task_e_68b890bb63ec83329e6b281bf1f17160