### PR TITLE
Split Windows and MacOS audio recorder implementations

### DIFF
--- a/composeApp/src/jvmMain/kotlin/de/lehrbaum/voiry/audio/MacOsAudioRecorder.jvm.kt
+++ b/composeApp/src/jvmMain/kotlin/de/lehrbaum/voiry/audio/MacOsAudioRecorder.jvm.kt
@@ -1,0 +1,28 @@
+package de.lehrbaum.voiry.audio
+
+import javax.sound.sampled.AudioSystem
+import javax.sound.sampled.DataLine
+import javax.sound.sampled.TargetDataLine
+
+class MacOsAudioRecorder : BaseAudioRecorder() {
+	override fun initializeLineAndFormat(): Boolean {
+		val mixerInfos = AudioSystem.getMixerInfo()
+		for (mixerInfo in mixerInfos) {
+			val mixer = AudioSystem.getMixer(mixerInfo)
+			val lineInfos = mixer.targetLineInfo
+			for (lineInfo in lineInfos) {
+				if (lineInfo is DataLine.Info) {
+					val line = mixer.getLine(lineInfo) as? TargetDataLine
+					val formats = lineInfo.formats
+					val format = formats.firstOrNull { it.sampleRate.toInt() != AudioSystem.NOT_SPECIFIED }
+					if (line != null && format != null) {
+						this.line = line
+						this.format = format
+						return true
+					}
+				}
+			}
+		}
+		return false
+	}
+}

--- a/composeApp/src/jvmMain/kotlin/de/lehrbaum/voiry/audio/PlatformRecorder.jvm.kt
+++ b/composeApp/src/jvmMain/kotlin/de/lehrbaum/voiry/audio/PlatformRecorder.jvm.kt
@@ -1,3 +1,8 @@
 package de.lehrbaum.voiry.audio
 
-actual val platformRecorder: Recorder by lazy { AudioRecorder() }
+import java.util.Locale
+
+actual val platformRecorder: Recorder by lazy {
+	val osName = System.getProperty("os.name")?.lowercase(Locale.getDefault()) ?: ""
+	if ("win" in osName) WindowsAudioRecorder() else MacOsAudioRecorder()
+}

--- a/composeApp/src/jvmMain/kotlin/de/lehrbaum/voiry/audio/WindowsAudioRecorder.jvm.kt
+++ b/composeApp/src/jvmMain/kotlin/de/lehrbaum/voiry/audio/WindowsAudioRecorder.jvm.kt
@@ -1,0 +1,22 @@
+package de.lehrbaum.voiry.audio
+
+import io.github.aakira.napier.Napier
+import javax.sound.sampled.AudioFormat
+import javax.sound.sampled.AudioSystem
+import javax.sound.sampled.DataLine
+import javax.sound.sampled.TargetDataLine
+
+class WindowsAudioRecorder : BaseAudioRecorder() {
+	override fun initializeLineAndFormat(): Boolean =
+		try {
+			val format = AudioFormat(44100f, 16, 1, true, false)
+			val info = DataLine.Info(TargetDataLine::class.java, format)
+			val line = AudioSystem.getLine(info) as TargetDataLine
+			this.line = line
+			this.format = format
+			true
+		} catch (e: Exception) {
+			Napier.w("Failed to initialize Windows audio line", e, tag = tag)
+			false
+		}
+}


### PR DESCRIPTION
## Summary
- factor shared recording logic into `BaseAudioRecorder`
- add Windows and MacOS implementations
- select platform-specific recorder at runtime

## Testing
- `./gradlew ktlintFormat`
- `./gradlew checkAgentsEnvironment`


------
https://chatgpt.com/codex/tasks/task_e_68b890e96be88332b9ca08218eb2e3c8