### PR TITLE
Exclude generated BuildKonfig from ktlint checks

### DIFF
--- a/composeApp/build.gradle.kts
+++ b/composeApp/build.gradle.kts
@@ -1,3 +1,5 @@
+import com.codingfeline.buildkonfig.compiler.FieldSpec.Type.STRING
+import java.util.Properties
 import org.gradle.api.tasks.testing.Test
 import org.jetbrains.compose.ExperimentalComposeLibrary
 import org.jetbrains.compose.desktop.application.dsl.TargetFormat
@@ -12,6 +14,27 @@ plugins {
 	alias(libs.plugins.composeHotReload)
 	alias(libs.plugins.kotlinSerialization)
 	alias(libs.plugins.mokkery)
+	alias(libs.plugins.buildkonfig)
+}
+
+val localProps = Properties().apply {
+	val f = rootProject.file("local.properties")
+	if (f.exists()) f.inputStream().use { load(it) }
+}
+val backendUrl = localProps.getProperty("backendUrl") ?: "http://localhost:8080"
+
+buildkonfig {
+	packageName = "de.lehrbaum.voiry"
+	exposeObjectWithName = "BuildKonfig"
+	defaultConfigs {
+		buildConfigField(STRING, "BACKEND_URL", backendUrl)
+	}
+}
+
+ktlint {
+	filter {
+		exclude("**/buildkonfig/**")
+	}
 }
 
 kotlin {

--- a/composeApp/src/commonMain/kotlin/de/lehrbaum/voiry/App.kt
+++ b/composeApp/src/commonMain/kotlin/de/lehrbaum/voiry/App.kt
@@ -8,6 +8,7 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
+import de.lehrbaum.voiry.BuildKonfig
 import de.lehrbaum.voiry.api.v1.DiaryClient
 import de.lehrbaum.voiry.audio.Transcriber
 import de.lehrbaum.voiry.audio.platformTranscriber
@@ -22,7 +23,7 @@ import org.jetbrains.compose.ui.tooling.preview.Preview
 @OptIn(ExperimentalUuidApi::class, ExperimentalTime::class)
 @Composable
 @Preview
-fun App(baseUrl: String = "http://localhost:8080", onRequestAudioPermission: (() -> Unit)? = null) {
+fun App(baseUrl: String = BuildKonfig.BACKEND_URL, onRequestAudioPermission: (() -> Unit)? = null) {
 	val diaryClient = remember { DiaryClient(baseUrl) }
 	val transcriber: Transcriber? = remember { platformTranscriber }
 	LaunchedEffect(transcriber) { transcriber?.initialize() }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -22,6 +22,7 @@ sqlite = "3.50.3.0"
 appdirs = "2.0.0"
 lexilabs-basic = "+"
 kotlinx-datetime = "0.7.1-0.6.x-compat"
+buildkonfig = "0.17.1"
 
 [libraries]
 kotlin-test = { module = "org.jetbrains.kotlin:kotlin-test", version.ref = "kotlin" }
@@ -65,3 +66,4 @@ kotlinMultiplatform = { id = "org.jetbrains.kotlin.multiplatform", version.ref =
 ktlint = { id = "org.jlleitschuh.gradle.ktlint", version.ref = "ktlint" }
 mokkery = { id = "dev.mokkery", version.ref = "mokkery" }
 kotlinSerialization = { id = "org.jetbrains.kotlin.plugin.serialization", version.ref = "kotlin" }
+buildkonfig = { id = "com.codingfeline.buildkonfig", version.ref = "buildkonfig" }


### PR DESCRIPTION
## Summary
- exclude composeApp's generated BuildKonfig.kt from ktlint checks

## Testing
- `./gradlew ktlintFormat`
- `./gradlew checkAgentsEnvironment --console=plain`


------
https://chatgpt.com/codex/tasks/task_e_68b88f7bd66483329df9cc6cf3dd104f