### PR TITLE
Add health endpoint for reliable Docker checks

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,6 +6,7 @@ RUN ./gradlew :server:buildFatJar --no-daemon
 
 # --- runtime stage ---
 FROM eclipse-temurin:17-jre
+RUN apt-get update && apt-get install -y curl && rm -rf /var/lib/apt/lists/*
 WORKDIR /app
 COPY --from=build /src/server/build/libs/*-all.jar app.jar
 ENV VOICE_DIARY_DB_PATH=/data

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,7 +3,14 @@ services:
   voice-diary:
     build: .
     ports:
-      - "8080:8080"
+      - "8888:8080"
     volumes:
       - ./data:/data
+    network_mode: "bridge"
+    restart: "on-failure:5"
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:8080/health"]
+      interval: 30s
+      timeout: 10s
+      retries: 5
 

--- a/server/src/main/kotlin/de/lehrbaum/voiry/Application.kt
+++ b/server/src/main/kotlin/de/lehrbaum/voiry/Application.kt
@@ -48,6 +48,9 @@ fun Application.module(service: DiaryService = runBlocking { DiaryServiceImpl.cr
 	install(SSE)
 
 	routing {
+		get("/health") {
+			call.respond(HttpStatusCode.OK)
+		}
 		route("/v1") {
 			sse("/entries") {
 				val json = Json

--- a/server/src/test/kotlin/de/lehrbaum/voiry/HealthEndpointTest.kt
+++ b/server/src/test/kotlin/de/lehrbaum/voiry/HealthEndpointTest.kt
@@ -1,0 +1,23 @@
+package de.lehrbaum.voiry
+
+import io.ktor.client.request.get
+import io.ktor.http.HttpStatusCode
+import io.ktor.server.testing.testApplication
+import java.nio.file.Files
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.time.ExperimentalTime
+import kotlin.uuid.ExperimentalUuidApi
+import kotlinx.coroutines.runBlocking
+
+@OptIn(ExperimentalUuidApi::class, ExperimentalTime::class)
+class HealthEndpointTest {
+	@Test
+	fun `GET health returns OK`() =
+		testApplication {
+			val service = runBlocking { DiaryServiceImpl.create(DiaryRepository(Files.createTempDirectory("healthTest"))) }
+			application { module(service) }
+			val response = client.get("/health")
+			assertEquals(HttpStatusCode.OK, response.status)
+		}
+}


### PR DESCRIPTION
## Summary
- add `/health` route returning 200 OK
- expose service on port 8888 with bridge network, restart policy, and health check hitting `/health`
- install curl in runtime image so health check succeeds
- test the health endpoint

## Testing
- `./gradlew --no-daemon ktlintFormat`
- `./gradlew checkAgentsEnvironment`


------
https://chatgpt.com/codex/tasks/task_e_68b89728f5e8833283f2736961af3f6f