### PR TITLE
Refactor EntryDetailScreen to use ViewModel

### DIFF
--- a/composeApp/src/commonMain/kotlin/de/lehrbaum/voiry/ui/EntryDetailScreen.kt
+++ b/composeApp/src/commonMain/kotlin/de/lehrbaum/voiry/ui/EntryDetailScreen.kt
@@ -16,31 +16,21 @@ import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.material3.TopAppBar
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.remember
-import androidx.compose.runtime.rememberCoroutineScope
-import androidx.compose.runtime.rememberUpdatedState
-import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import androidx.lifecycle.viewmodel.compose.viewModel
 import de.lehrbaum.voiry.api.v1.DiaryClient
-import de.lehrbaum.voiry.api.v1.TranscriptionStatus
-import de.lehrbaum.voiry.api.v1.UpdateTranscriptionRequest
 import de.lehrbaum.voiry.audio.Player
 import de.lehrbaum.voiry.audio.Transcriber
 import de.lehrbaum.voiry.audio.platformPlayer
 import de.lehrbaum.voiry.audio.platformTranscriber
-import kotlin.time.Clock
 import kotlin.time.ExperimentalTime
 import kotlin.uuid.ExperimentalUuidApi
 import kotlin.uuid.Uuid
-import kotlinx.coroutines.launch
 import kotlinx.datetime.TimeZone
 import kotlinx.datetime.toLocalDateTime
-import kotlinx.io.Buffer
 
 @OptIn(ExperimentalMaterial3Api::class, ExperimentalUuidApi::class, ExperimentalTime::class, ExperimentalLayoutApi::class)
 @Composable
@@ -51,35 +41,17 @@ fun EntryDetailScreen(
 	player: Player = platformPlayer,
 	transcriber: Transcriber? = platformTranscriber,
 ) {
-	val scope = rememberCoroutineScope()
-	val entryFlow = remember(entryId) { diaryClient.entryFlow(entryId) }
-	val entry = entryFlow.collectAsStateWithLifecycle().value ?: return
-	var audio by remember { mutableStateOf<ByteArray?>(null) }
-	var isPlaying by remember { mutableStateOf(false) }
-	var error by remember { mutableStateOf<String?>(null) }
-	var isEditing by remember { mutableStateOf(false) }
-	var editedText by remember { mutableStateOf(entry.transcriptionText ?: "") }
-	var isSaving by remember { mutableStateOf(false) }
-
-	androidx.compose.runtime.LaunchedEffect(entryId) {
-		runCatching { diaryClient.getAudio(entryId) }
-			.onSuccess { audio = it }
-			.onFailure { e -> error = e.message }
+	val viewModel = viewModel<EntryDetailViewModel>(key = entryId.toString()) {
+		EntryDetailViewModel(diaryClient, entryId, player, transcriber)
 	}
-
-	DisposableEffect(player) {
-		onDispose {
-			player.close()
-		}
-	}
+	val state by viewModel.uiState.collectAsStateWithLifecycle()
+	val entry = state.entry ?: return
 
 	Scaffold(
 		topBar = {
 			TopAppBar(
 				title = { Text(entry.title) },
-				navigationIcon = {
-					TextButton(onClick = onBack) { Text("Back") }
-				},
+				navigationIcon = { TextButton(onClick = onBack) { Text("Back") } },
 			)
 		},
 	) { padding ->
@@ -109,55 +81,32 @@ fun EntryDetailScreen(
 						}
 					}
 			Text("Recorded at: $recordedAtFormatted")
-			if (isEditing) {
+			if (state.isEditing) {
 				OutlinedTextField(
-					value = editedText,
-					onValueChange = { editedText = it },
+					value = state.editedText,
+					onValueChange = { viewModel.updateEditedText(it) },
 					modifier = Modifier.fillMaxWidth(),
 				)
 				Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
 					TextButton(
-						enabled = !isSaving,
-						onClick = {
-							isEditing = false
-							editedText = entry.transcriptionText ?: ""
-						},
+						enabled = !state.isSaving,
+						onClick = { viewModel.cancelEdit() },
 					) { Text("Cancel") }
 					TextButton(
 						enabled =
-							!isSaving &&
-								editedText.isNotBlank() &&
-								editedText != (entry.transcriptionText ?: ""),
-						onClick = {
-							scope.launch {
-								isSaving = true
-								runCatching {
-									diaryClient.updateTranscription(
-										entry.id,
-										UpdateTranscriptionRequest(
-											editedText,
-											TranscriptionStatus.DONE,
-											Clock.System.now(),
-										),
-									)
-								}.onSuccess {
-									isEditing = false
-								}.onFailure { e -> error = e.message }
-								isSaving = false
-							}
-						},
+							!state.isSaving &&
+								state.editedText.isNotBlank() &&
+								state.editedText != (entry.transcriptionText ?: ""),
+						onClick = { viewModel.saveEdit() },
 					) { Text("Save") }
 				}
-				if (isSaving) {
+				if (state.isSaving) {
 					CircularProgressIndicator()
 				}
 			} else {
 				Text(entry.transcriptionText ?: entry.transcriptionStatus.displayName())
 				TextButton(
-					onClick = {
-						editedText = entry.transcriptionText ?: ""
-						isEditing = true
-					},
+					onClick = { viewModel.startEditing() },
 				) { Text("Edit") }
 			}
 			FlowRow(
@@ -165,77 +114,26 @@ fun EntryDetailScreen(
 				horizontalArrangement = Arrangement.spacedBy(8.dp),
 				verticalArrangement = Arrangement.spacedBy(8.dp),
 			) {
-				audio?.let { data ->
+				state.audio?.let {
 					TextButton(
-						onClick = {
-							if (isPlaying) {
-								player.stop()
-							} else {
-								player.play(data)
-							}
-							isPlaying = !isPlaying
-						},
+						onClick = { viewModel.togglePlayback() },
 					) {
-						Text(if (isPlaying) "Stop" else "Play")
+						Text(if (state.isPlaying) "Stop" else "Play")
 					}
 				}
-				val latestAudio by rememberUpdatedState(audio)
-				val setError by rememberUpdatedState<(String?) -> Unit> { error = it }
-				val transcribeAction = remember(diaryClient, transcriber, entry.id, scope, setError) {
-					{
-						val audioData = latestAudio
-						val t = transcriber
-						if (audioData != null && t != null) {
-							scope.launch {
-								transcribeEntry(
-									diaryClient,
-									t,
-									entry.id,
-									audioData,
-								).onFailure { e -> setError(e.message) }
-							}
-						} else if (t == null) {
-							setError("Transcriber unavailable")
-						}
-						Unit
-					}
-				}
-				TranscribeButtonWithProgress(transcriber = transcriber, onTranscribe = transcribeAction)
+				TranscribeButtonWithProgress(
+					transcriber = viewModel.transcriber,
+					onTranscribe = { viewModel.transcribe() },
+				)
 				TextButton(
-					onClick = {
-						scope.launch {
-							runCatching { diaryClient.deleteEntry(entry.id) }
-								.onSuccess { onBack() }
-								.onFailure { e -> error = e.message }
-						}
-					},
+					onClick = { viewModel.delete(onBack) },
 				) {
 					Text("Delete")
 				}
 			}
-			if (error != null) {
-				Text("Error: $error")
+			if (state.error != null) {
+				Text("Error: ${state.error}")
 			}
 		}
 	}
 }
-
-@OptIn(ExperimentalTime::class, ExperimentalUuidApi::class)
-private suspend fun transcribeEntry(
-	diaryClient: DiaryClient,
-	transcriber: Transcriber,
-	entryId: Uuid,
-	audio: ByteArray,
-): Result<Unit> =
-	runCatching {
-		val buffer = Buffer().apply { write(audio) }
-		val text = transcriber.transcribe(buffer)
-		diaryClient.updateTranscription(
-			entryId,
-			UpdateTranscriptionRequest(
-				text,
-				TranscriptionStatus.DONE,
-				Clock.System.now(),
-			),
-		)
-	}

--- a/composeApp/src/commonMain/kotlin/de/lehrbaum/voiry/ui/EntryDetailViewModel.kt
+++ b/composeApp/src/commonMain/kotlin/de/lehrbaum/voiry/ui/EntryDetailViewModel.kt
@@ -1,0 +1,160 @@
+package de.lehrbaum.voiry.ui
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import de.lehrbaum.voiry.api.v1.DiaryClient
+import de.lehrbaum.voiry.api.v1.TranscriptionStatus
+import de.lehrbaum.voiry.api.v1.UpdateTranscriptionRequest
+import de.lehrbaum.voiry.api.v1.VoiceDiaryEntry
+import de.lehrbaum.voiry.audio.Player
+import de.lehrbaum.voiry.audio.Transcriber
+import de.lehrbaum.voiry.audio.platformPlayer
+import de.lehrbaum.voiry.audio.platformTranscriber
+import java.io.Closeable
+import kotlin.time.Clock
+import kotlin.time.ExperimentalTime
+import kotlin.uuid.ExperimentalUuidApi
+import kotlin.uuid.Uuid
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
+import kotlinx.io.Buffer
+
+@OptIn(ExperimentalUuidApi::class, ExperimentalTime::class)
+class EntryDetailViewModel(
+	private val diaryClient: DiaryClient,
+	private val entryId: Uuid,
+	private val player: Player = platformPlayer,
+	val transcriber: Transcriber? = platformTranscriber,
+) : ViewModel(), Closeable {
+	private val _uiState = MutableStateFlow(EntryDetailUiState())
+	val uiState: StateFlow<EntryDetailUiState> = _uiState.asStateFlow()
+
+	init {
+		viewModelScope.launch {
+			diaryClient.entryFlow(entryId).collect { entry ->
+				_uiState.update {
+					it.copy(
+						entry = entry,
+						editedText = if (!it.isEditing) entry?.transcriptionText ?: "" else it.editedText,
+					)
+				}
+			}
+		}
+		viewModelScope.launch {
+			runCatching { diaryClient.getAudio(entryId) }
+				.onSuccess { data -> _uiState.update { it.copy(audio = data) } }
+				.onFailure { e -> _uiState.update { it.copy(error = e.message) } }
+		}
+	}
+
+	override fun onCleared() {
+		super.onCleared()
+		close()
+	}
+
+	override fun close() {
+		runCatching { player.close() }
+	}
+
+	fun togglePlayback() {
+		val audio = _uiState.value.audio ?: return
+		if (_uiState.value.isPlaying) {
+			player.stop()
+		} else {
+			player.play(audio)
+		}
+		_uiState.update { it.copy(isPlaying = !it.isPlaying) }
+	}
+
+	fun startEditing() {
+		_uiState.update { state ->
+			state.copy(isEditing = true, editedText = state.entry?.transcriptionText ?: "")
+		}
+	}
+
+	fun updateEditedText(text: String) {
+		_uiState.update { it.copy(editedText = text) }
+	}
+
+	fun cancelEdit() {
+		_uiState.update { state ->
+			state.copy(isEditing = false, editedText = state.entry?.transcriptionText ?: "")
+		}
+	}
+
+	fun saveEdit() {
+		val entry = _uiState.value.entry ?: return
+		val edited = _uiState.value.editedText
+		viewModelScope.launch {
+			_uiState.update { it.copy(isSaving = true) }
+			runCatching {
+				diaryClient.updateTranscription(
+					entry.id,
+					UpdateTranscriptionRequest(
+						edited,
+						TranscriptionStatus.DONE,
+						Clock.System.now(),
+					),
+				)
+			}.onSuccess {
+				_uiState.update { it.copy(isSaving = false, isEditing = false) }
+			}.onFailure { e ->
+				_uiState.update { it.copy(isSaving = false, error = e.message) }
+			}
+		}
+	}
+
+	fun transcribe() {
+		val audio = _uiState.value.audio ?: return
+		val t = transcriber
+		if (t == null) {
+			_uiState.update { it.copy(error = "Transcriber unavailable") }
+			return
+		}
+		viewModelScope.launch {
+			transcribeEntry(diaryClient, t, entryId, audio)
+				.onFailure { e -> _uiState.update { it.copy(error = e.message) } }
+		}
+	}
+
+	fun delete(onSuccess: () -> Unit) {
+		viewModelScope.launch {
+			runCatching { diaryClient.deleteEntry(entryId) }
+				.onSuccess { onSuccess() }
+				.onFailure { e -> _uiState.update { it.copy(error = e.message) } }
+		}
+	}
+}
+
+data class EntryDetailUiState(
+	val entry: VoiceDiaryEntry? = null,
+	val audio: ByteArray? = null,
+	val isPlaying: Boolean = false,
+	val error: String? = null,
+	val isEditing: Boolean = false,
+	val editedText: String = "",
+	val isSaving: Boolean = false,
+)
+
+@OptIn(ExperimentalUuidApi::class, ExperimentalTime::class)
+private suspend fun transcribeEntry(
+	diaryClient: DiaryClient,
+	transcriber: Transcriber,
+	entryId: Uuid,
+	audio: ByteArray,
+): Result<Unit> =
+	runCatching {
+		val buffer = Buffer().apply { write(audio) }
+		val text = transcriber.transcribe(buffer)
+		diaryClient.updateTranscription(
+			entryId,
+			UpdateTranscriptionRequest(
+				text,
+				TranscriptionStatus.DONE,
+				Clock.System.now(),
+			),
+		)
+	}

--- a/composeApp/src/jvmTest/kotlin/de/lehrbaum/voiry/ui/EntryDetailScreenTest.kt
+++ b/composeApp/src/jvmTest/kotlin/de/lehrbaum/voiry/ui/EntryDetailScreenTest.kt
@@ -15,7 +15,10 @@ import androidx.compose.ui.test.runComposeUiTest
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.LifecycleOwner
 import androidx.lifecycle.LifecycleRegistry
+import androidx.lifecycle.ViewModelStore
+import androidx.lifecycle.ViewModelStoreOwner
 import androidx.lifecycle.compose.LocalLifecycleOwner
+import androidx.lifecycle.viewmodel.compose.LocalViewModelStoreOwner
 import de.lehrbaum.voiry.UiTest
 import de.lehrbaum.voiry.api.v1.DiaryClient
 import de.lehrbaum.voiry.api.v1.TranscriptionStatus
@@ -60,7 +63,10 @@ class EntryDetailScreenTest {
 			every { player.isAvailable } returns true
 
 			setContent {
-				CompositionLocalProvider(LocalLifecycleOwner provides EntryFakeLifecycleOwner()) {
+				CompositionLocalProvider(
+					LocalLifecycleOwner provides EntryFakeLifecycleOwner(),
+					LocalViewModelStoreOwner provides EntryFakeViewModelStoreOwner(),
+				) {
 					MaterialTheme {
 						EntryDetailScreen(
 							diaryClient = client,
@@ -103,7 +109,10 @@ class EntryDetailScreenTest {
 			every { player.isAvailable } returns true
 
 			setContent {
-				CompositionLocalProvider(LocalLifecycleOwner provides EntryFakeLifecycleOwner()) {
+				CompositionLocalProvider(
+					LocalLifecycleOwner provides EntryFakeLifecycleOwner(),
+					LocalViewModelStoreOwner provides EntryFakeViewModelStoreOwner(),
+				) {
 					MaterialTheme {
 						EntryDetailScreen(
 							diaryClient = client,
@@ -151,7 +160,10 @@ class EntryDetailScreenTest {
 			every { player.isAvailable } returns true
 
 			setContent {
-				CompositionLocalProvider(LocalLifecycleOwner provides EntryFakeLifecycleOwner()) {
+				CompositionLocalProvider(
+					LocalLifecycleOwner provides EntryFakeLifecycleOwner(),
+					LocalViewModelStoreOwner provides EntryFakeViewModelStoreOwner(),
+				) {
 					MaterialTheme {
 						EntryDetailScreen(
 							diaryClient = client,
@@ -186,7 +198,10 @@ class EntryDetailScreenTest {
 			var backCalled = false
 
 			setContent {
-				CompositionLocalProvider(LocalLifecycleOwner provides EntryFakeLifecycleOwner()) {
+				CompositionLocalProvider(
+					LocalLifecycleOwner provides EntryFakeLifecycleOwner(),
+					LocalViewModelStoreOwner provides EntryFakeViewModelStoreOwner(),
+				) {
 					MaterialTheme {
 						EntryDetailScreen(
 							diaryClient = client,
@@ -224,7 +239,10 @@ class EntryDetailScreenTest {
 			var backCalled = false
 
 			setContent {
-				CompositionLocalProvider(LocalLifecycleOwner provides EntryFakeLifecycleOwner()) {
+				CompositionLocalProvider(
+					LocalLifecycleOwner provides EntryFakeLifecycleOwner(),
+					LocalViewModelStoreOwner provides EntryFakeViewModelStoreOwner(),
+				) {
 					MaterialTheme {
 						EntryDetailScreen(
 							diaryClient = client,
@@ -262,7 +280,10 @@ class EntryDetailScreenTest {
 			every { player.isAvailable } returns true
 
 			setContent {
-				CompositionLocalProvider(LocalLifecycleOwner provides EntryFakeLifecycleOwner()) {
+				CompositionLocalProvider(
+					LocalLifecycleOwner provides EntryFakeLifecycleOwner(),
+					LocalViewModelStoreOwner provides EntryFakeViewModelStoreOwner(),
+				) {
 					MaterialTheme {
 						EntryDetailScreen(
 							diaryClient = client,
@@ -322,6 +343,10 @@ private class EntryFakeLifecycleOwner : LifecycleOwner {
 		currentState = Lifecycle.State.RESUMED
 	}
 	override val lifecycle: Lifecycle get() = registry
+}
+
+private class EntryFakeViewModelStoreOwner : ViewModelStoreOwner {
+	override val viewModelStore: ViewModelStore = ViewModelStore()
 }
 
 private class ReadyTranscriber : Transcriber {

--- a/composeApp/src/jvmTest/kotlin/de/lehrbaum/voiry/ui/NavigationViewModelTest.kt
+++ b/composeApp/src/jvmTest/kotlin/de/lehrbaum/voiry/ui/NavigationViewModelTest.kt
@@ -1,0 +1,129 @@
+package de.lehrbaum.voiry.ui
+
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.test.ExperimentalTestApi
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performClick
+import androidx.compose.ui.test.runComposeUiTest
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.LifecycleOwner
+import androidx.lifecycle.LifecycleRegistry
+import androidx.lifecycle.ViewModelStore
+import androidx.lifecycle.ViewModelStoreOwner
+import androidx.lifecycle.compose.LocalLifecycleOwner
+import androidx.lifecycle.viewmodel.compose.LocalViewModelStoreOwner
+import de.lehrbaum.voiry.UiTest
+import de.lehrbaum.voiry.api.v1.DiaryClient
+import de.lehrbaum.voiry.api.v1.TranscriptionStatus
+import de.lehrbaum.voiry.api.v1.VoiceDiaryEntry
+import de.lehrbaum.voiry.audio.Player
+import de.lehrbaum.voiry.audio.Recorder
+import dev.mokkery.MockMode
+import dev.mokkery.answering.returns
+import dev.mokkery.every
+import dev.mokkery.mock
+import io.ktor.client.HttpClient
+import kotlin.time.Clock
+import kotlin.time.Duration
+import kotlin.time.ExperimentalTime
+import kotlin.uuid.ExperimentalUuidApi
+import kotlin.uuid.Uuid
+import kotlinx.coroutines.flow.MutableStateFlow
+import org.junit.Test
+import org.junit.experimental.categories.Category
+
+@OptIn(ExperimentalTestApi::class, ExperimentalTime::class, ExperimentalUuidApi::class)
+@Category(UiTest::class)
+class NavigationViewModelTest {
+	@Test
+	fun opening_different_entries_uses_new_view_model() =
+		runComposeUiTest {
+			val entry1 = VoiceDiaryEntry(
+				id = Uuid.random(),
+				title = "Recording 1",
+				recordedAt = Clock.System.now(),
+				duration = Duration.ZERO,
+				transcriptionText = "Transcript 1",
+				transcriptionStatus = TranscriptionStatus.DONE,
+			)
+			val entry2 = VoiceDiaryEntry(
+				id = Uuid.random(),
+				title = "Recording 2",
+				recordedAt = Clock.System.now(),
+				duration = Duration.ZERO,
+				transcriptionText = "Transcript 2",
+				transcriptionStatus = TranscriptionStatus.DONE,
+			)
+			val client = NavigationFakeDiaryClient(listOf(entry1, entry2))
+			val recorder = mock<Recorder>()
+			every { recorder.isAvailable } returns false
+			val player = mock<Player>(mode = MockMode.autoUnit)
+			every { player.isAvailable } returns true
+
+			setContent {
+				CompositionLocalProvider(
+					LocalLifecycleOwner provides NavigationFakeLifecycleOwner(),
+					LocalViewModelStoreOwner provides NavigationFakeViewModelStoreOwner(),
+				) {
+					MaterialTheme {
+						var selectedEntryId by remember { mutableStateOf<Uuid?>(null) }
+						if (selectedEntryId == null) {
+							MainScreen(
+								diaryClient = client,
+								recorder = recorder,
+								onEntryClick = { selectedEntryId = it.id },
+							)
+						} else {
+							EntryDetailScreen(
+								diaryClient = client,
+								entryId = selectedEntryId!!,
+								onBack = { selectedEntryId = null },
+								player = player,
+								transcriber = null,
+							)
+						}
+					}
+				}
+			}
+
+			waitForIdle()
+
+			onNodeWithText("Recording 1", substring = false).performClick()
+			waitForIdle()
+			onNodeWithText("Transcript 1", substring = false).assertIsDisplayed()
+
+			onNodeWithText("Back", substring = false).performClick()
+			waitForIdle()
+
+			onNodeWithText("Recording 2", substring = false).performClick()
+			waitForIdle()
+			onNodeWithText("Transcript 2", substring = false).assertIsDisplayed()
+		}
+}
+
+@OptIn(ExperimentalUuidApi::class, ExperimentalTime::class)
+private class NavigationFakeDiaryClient(
+	entries: List<VoiceDiaryEntry>,
+) : DiaryClient(baseUrl = "", httpClient = HttpClient()) {
+	private val _entries = MutableStateFlow(entries)
+	override val entries: MutableStateFlow<List<VoiceDiaryEntry>> get() = _entries
+
+	override suspend fun getAudio(id: Uuid): ByteArray = byteArrayOf(0)
+}
+
+private class NavigationFakeLifecycleOwner : LifecycleOwner {
+	private val registry = LifecycleRegistry(this).apply {
+		currentState = Lifecycle.State.RESUMED
+	}
+	override val lifecycle: Lifecycle get() = registry
+}
+
+private class NavigationFakeViewModelStoreOwner : ViewModelStoreOwner {
+	override val viewModelStore: ViewModelStore = ViewModelStore()
+}


### PR DESCRIPTION
## Summary
- move entry detail logic into new EntryDetailViewModel
- make EntryDetailScreen read immutable uiState and delegate events to ViewModel
- adjust tests to supply ViewModelStoreOwner
- ensure a new EntryDetailViewModel instance is created for each entry by keying with entryId
- add a navigation test that opens two different entries to verify ViewModel isolation

## Testing
- `./gradlew ktlintFormat`
- `./gradlew checkAgentsEnvironment`


------
https://chatgpt.com/codex/tasks/task_e_68b8a3d811448332ab2b854677e9ef6f