### PR TITLE
Use Eclipse Temurin JDK and Gradle wrapper in Docker build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,12 @@
 # --- build stage ---
-FROM gradle:8.5-jdk17 AS build
+FROM eclipse-temurin:17-jdk AS build
 WORKDIR /src
+
+# Copy project sources (including Gradle wrapper)
 COPY . .
+RUN chmod +x gradlew
+
+# Build the server fat JAR using the wrapper
 RUN ./gradlew :server:buildFatJar --no-daemon
 
 # --- runtime stage ---


### PR DESCRIPTION
## Summary
- build server image from eclipse-temurin JDK base
- copy entire project once and build using Gradle wrapper

## Testing
- `./gradlew ktlintFormat`
- `./gradlew checkAgentsEnvironment`


------
https://chatgpt.com/codex/tasks/task_e_68b9190d31dc8332b929b6a060dde7f4