### PR TITLE
Use port 8888 for server and client defaults

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,6 +10,6 @@ WORKDIR /app
 COPY --from=build /src/server/build/libs/*-all.jar app.jar
 ENV VOICE_DIARY_DB_PATH=/data
 VOLUME /data
-EXPOSE 8080
+EXPOSE 8888
 ENTRYPOINT ["java","-jar","/app/app.jar"]
 

--- a/composeApp/build.gradle.kts
+++ b/composeApp/build.gradle.kts
@@ -21,7 +21,7 @@ val localProps = Properties().apply {
 	val f = rootProject.file("local.properties")
 	if (f.exists()) f.inputStream().use { load(it) }
 }
-val backendUrl = localProps.getProperty("backendUrl") ?: "http://localhost:8080"
+val backendUrl = localProps.getProperty("backendUrl") ?: "http://localhost:8888"
 
 buildkonfig {
 	packageName = "de.lehrbaum.voiry"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,13 +3,13 @@ services:
   voice-diary:
     build: .
     ports:
-      - "8888:8080"
+      - "8888:8888"
     volumes:
       - ./data:/data
     network_mode: "bridge"
     restart: "on-failure:5"
     healthcheck:
-      test: ["CMD", "curl", "-f", "http://localhost:8080/health"]
+      test: ["CMD", "curl", "-f", "http://localhost:8888/health"]
       interval: 30s
       timeout: 10s
       retries: 5

--- a/shared/src/commonMain/kotlin/de/lehrbaum/voiry/Constants.kt
+++ b/shared/src/commonMain/kotlin/de/lehrbaum/voiry/Constants.kt
@@ -1,3 +1,3 @@
 package de.lehrbaum.voiry
 
-const val SERVER_PORT = 8080
+const val SERVER_PORT = 8888


### PR DESCRIPTION
## Summary
- default server port changed to 8888 and Docker assets aligned
- client backend default updated to http://localhost:8888

## Testing
- `./gradlew ktlintFormat`
- `./gradlew checkAgentsEnvironment`


------
https://chatgpt.com/codex/tasks/task_e_68b921a9e5e08332b47f64d1a699a61f