### PR TITLE
Refactor EntryDetailScreen to use ViewModel

### DIFF
--- a/composeApp/src/commonMain/kotlin/de/lehrbaum/voiry/ui/EntryDetailViewModel.kt
+++ b/composeApp/src/commonMain/kotlin/de/lehrbaum/voiry/ui/EntryDetailViewModel.kt
@@ -1,0 +1,160 @@
+package de.lehrbaum.voiry.ui
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import de.lehrbaum.voiry.api.v1.DiaryClient
+import de.lehrbaum.voiry.api.v1.TranscriptionStatus
+import de.lehrbaum.voiry.api.v1.UpdateTranscriptionRequest
+import de.lehrbaum.voiry.api.v1.VoiceDiaryEntry
+import de.lehrbaum.voiry.audio.Player
+import de.lehrbaum.voiry.audio.Transcriber
+import de.lehrbaum.voiry.audio.platformPlayer
+import de.lehrbaum.voiry.audio.platformTranscriber
+import java.io.Closeable
+import kotlin.time.Clock
+import kotlin.time.ExperimentalTime
+import kotlin.uuid.ExperimentalUuidApi
+import kotlin.uuid.Uuid
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
+import kotlinx.io.Buffer
+
+@OptIn(ExperimentalUuidApi::class, ExperimentalTime::class)
+class EntryDetailViewModel(
+	private val diaryClient: DiaryClient,
+	private val entryId: Uuid,
+	private val player: Player = platformPlayer,
+	val transcriber: Transcriber? = platformTranscriber,
+) : ViewModel(), Closeable {
+	private val _uiState = MutableStateFlow(EntryDetailUiState())
+	val uiState: StateFlow<EntryDetailUiState> = _uiState.asStateFlow()
+
+	init {
+		viewModelScope.launch {
+			diaryClient.entryFlow(entryId).collect { entry ->
+				_uiState.update {
+					it.copy(
+						entry = entry,
+						editedText = if (!it.isEditing) entry?.transcriptionText ?: "" else it.editedText,
+					)
+				}
+			}
+		}
+		viewModelScope.launch {
+			runCatching { diaryClient.getAudio(entryId) }
+				.onSuccess { data -> _uiState.update { it.copy(audio = data) } }
+				.onFailure { e -> _uiState.update { it.copy(error = e.message) } }
+		}
+	}
+
+	override fun onCleared() {
+		super.onCleared()
+		close()
+	}
+
+	override fun close() {
+		runCatching { player.close() }
+	}
+
+	fun togglePlayback() {
+		val audio = _uiState.value.audio ?: return
+		if (_uiState.value.isPlaying) {
+			player.stop()
+		} else {
+			player.play(audio)
+		}
+		_uiState.update { it.copy(isPlaying = !it.isPlaying) }
+	}
+
+	fun startEditing() {
+		_uiState.update { state ->
+			state.copy(isEditing = true, editedText = state.entry?.transcriptionText ?: "")
+		}
+	}
+
+	fun updateEditedText(text: String) {
+		_uiState.update { it.copy(editedText = text) }
+	}
+
+	fun cancelEdit() {
+		_uiState.update { state ->
+			state.copy(isEditing = false, editedText = state.entry?.transcriptionText ?: "")
+		}
+	}
+
+	fun saveEdit() {
+		val entry = _uiState.value.entry ?: return
+		val edited = _uiState.value.editedText
+		viewModelScope.launch {
+			_uiState.update { it.copy(isSaving = true) }
+			runCatching {
+				diaryClient.updateTranscription(
+					entry.id,
+					UpdateTranscriptionRequest(
+						edited,
+						TranscriptionStatus.DONE,
+						Clock.System.now(),
+					),
+				)
+			}.onSuccess {
+				_uiState.update { it.copy(isSaving = false, isEditing = false) }
+			}.onFailure { e ->
+				_uiState.update { it.copy(isSaving = false, error = e.message) }
+			}
+		}
+	}
+
+	fun transcribe() {
+		val audio = _uiState.value.audio ?: return
+		val t = transcriber
+		if (t == null) {
+			_uiState.update { it.copy(error = "Transcriber unavailable") }
+			return
+		}
+		viewModelScope.launch {
+			transcribeEntry(diaryClient, t, entryId, audio)
+				.onFailure { e -> _uiState.update { it.copy(error = e.message) } }
+		}
+	}
+
+	fun delete(onSuccess: () -> Unit) {
+		viewModelScope.launch {
+			runCatching { diaryClient.deleteEntry(entryId) }
+				.onSuccess { onSuccess() }
+				.onFailure { e -> _uiState.update { it.copy(error = e.message) } }
+		}
+	}
+}
+
+data class EntryDetailUiState(
+	val entry: VoiceDiaryEntry? = null,
+	val audio: ByteArray? = null,
+	val isPlaying: Boolean = false,
+	val error: String? = null,
+	val isEditing: Boolean = false,
+	val editedText: String = "",
+	val isSaving: Boolean = false,
+)
+
+@OptIn(ExperimentalUuidApi::class, ExperimentalTime::class)
+private suspend fun transcribeEntry(
+	diaryClient: DiaryClient,
+	transcriber: Transcriber,
+	entryId: Uuid,
+	audio: ByteArray,
+): Result<Unit> =
+	runCatching {
+		val buffer = Buffer().apply { write(audio) }
+		val text = transcriber.transcribe(buffer)
+		diaryClient.updateTranscription(
+			entryId,
+			UpdateTranscriptionRequest(
+				text,
+				TranscriptionStatus.DONE,
+				Clock.System.now(),
+			),
+		)
+	}

--- a/composeApp/src/jvmTest/kotlin/de/lehrbaum/voiry/ui/EntryDetailScreenTest.kt
+++ b/composeApp/src/jvmTest/kotlin/de/lehrbaum/voiry/ui/EntryDetailScreenTest.kt
@@ -15,7 +15,10 @@ import androidx.compose.ui.test.runComposeUiTest
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.LifecycleOwner
 import androidx.lifecycle.LifecycleRegistry
+import androidx.lifecycle.ViewModelStore
+import androidx.lifecycle.ViewModelStoreOwner
 import androidx.lifecycle.compose.LocalLifecycleOwner
+import androidx.lifecycle.viewmodel.compose.LocalViewModelStoreOwner
 import de.lehrbaum.voiry.UiTest
 import de.lehrbaum.voiry.api.v1.DiaryClient
 import de.lehrbaum.voiry.api.v1.TranscriptionStatus
@@ -60,7 +63,10 @@ class EntryDetailScreenTest {
 			every { player.isAvailable } returns true
 
 			setContent {
-				CompositionLocalProvider(LocalLifecycleOwner provides EntryFakeLifecycleOwner()) {
+				CompositionLocalProvider(
+					LocalLifecycleOwner provides EntryFakeLifecycleOwner(),
+					LocalViewModelStoreOwner provides EntryFakeViewModelStoreOwner(),
+				) {
 					MaterialTheme {
 						EntryDetailScreen(
 							diaryClient = client,
@@ -103,7 +109,10 @@ class EntryDetailScreenTest {
 			every { player.isAvailable } returns true
 
 			setContent {
-				CompositionLocalProvider(LocalLifecycleOwner provides EntryFakeLifecycleOwner()) {
+				CompositionLocalProvider(
+					LocalLifecycleOwner provides EntryFakeLifecycleOwner(),
+					LocalViewModelStoreOwner provides EntryFakeViewModelStoreOwner(),
+				) {
 					MaterialTheme {
 						EntryDetailScreen(
 							diaryClient = client,
@@ -151,7 +160,10 @@ class EntryDetailScreenTest {
 			every { player.isAvailable } returns true
 
 			setContent {
-				CompositionLocalProvider(LocalLifecycleOwner provides EntryFakeLifecycleOwner()) {
+				CompositionLocalProvider(
+					LocalLifecycleOwner provides EntryFakeLifecycleOwner(),
+					LocalViewModelStoreOwner provides EntryFakeViewModelStoreOwner(),
+				) {
 					MaterialTheme {
 						EntryDetailScreen(
 							diaryClient = client,
@@ -186,7 +198,10 @@ class EntryDetailScreenTest {
 			var backCalled = false
 
 			setContent {
-				CompositionLocalProvider(LocalLifecycleOwner provides EntryFakeLifecycleOwner()) {
+				CompositionLocalProvider(
+					LocalLifecycleOwner provides EntryFakeLifecycleOwner(),
+					LocalViewModelStoreOwner provides EntryFakeViewModelStoreOwner(),
+				) {
 					MaterialTheme {
 						EntryDetailScreen(
 							diaryClient = client,
@@ -224,7 +239,10 @@ class EntryDetailScreenTest {
 			var backCalled = false
 
 			setContent {
-				CompositionLocalProvider(LocalLifecycleOwner provides EntryFakeLifecycleOwner()) {
+				CompositionLocalProvider(
+					LocalLifecycleOwner provides EntryFakeLifecycleOwner(),
+					LocalViewModelStoreOwner provides EntryFakeViewModelStoreOwner(),
+				) {
 					MaterialTheme {
 						EntryDetailScreen(
 							diaryClient = client,
@@ -262,7 +280,10 @@ class EntryDetailScreenTest {
 			every { player.isAvailable } returns true
 
 			setContent {
-				CompositionLocalProvider(LocalLifecycleOwner provides EntryFakeLifecycleOwner()) {
+				CompositionLocalProvider(
+					LocalLifecycleOwner provides EntryFakeLifecycleOwner(),
+					LocalViewModelStoreOwner provides EntryFakeViewModelStoreOwner(),
+				) {
 					MaterialTheme {
 						EntryDetailScreen(
 							diaryClient = client,
@@ -322,6 +343,10 @@ private class EntryFakeLifecycleOwner : LifecycleOwner {
 		currentState = Lifecycle.State.RESUMED
 	}
 	override val lifecycle: Lifecycle get() = registry
+}
+
+private class EntryFakeViewModelStoreOwner : ViewModelStoreOwner {
+	override val viewModelStore: ViewModelStore = ViewModelStore()
 }
 
 private class ReadyTranscriber : Transcriber {

--- a/composeApp/src/jvmTest/kotlin/de/lehrbaum/voiry/ui/NavigationViewModelTest.kt
+++ b/composeApp/src/jvmTest/kotlin/de/lehrbaum/voiry/ui/NavigationViewModelTest.kt
@@ -1,0 +1,139 @@
+package de.lehrbaum.voiry.ui
+
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.test.ExperimentalTestApi
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performClick
+import androidx.compose.ui.test.runComposeUiTest
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.LifecycleOwner
+import androidx.lifecycle.LifecycleRegistry
+import androidx.lifecycle.ViewModelStore
+import androidx.lifecycle.ViewModelStoreOwner
+import androidx.lifecycle.compose.LocalLifecycleOwner
+import androidx.lifecycle.viewmodel.compose.LocalViewModelStoreOwner
+import de.lehrbaum.voiry.UiTest
+import de.lehrbaum.voiry.api.v1.DiaryClient
+import de.lehrbaum.voiry.api.v1.TranscriptionStatus
+import de.lehrbaum.voiry.api.v1.VoiceDiaryEntry
+import de.lehrbaum.voiry.audio.Player
+import de.lehrbaum.voiry.audio.Recorder
+import dev.mokkery.MockMode
+import dev.mokkery.answering.returns
+import dev.mokkery.every
+import dev.mokkery.mock
+import dev.mokkery.verify
+import io.ktor.client.HttpClient
+import kotlin.time.Clock
+import kotlin.time.Duration
+import kotlin.time.ExperimentalTime
+import kotlin.uuid.ExperimentalUuidApi
+import kotlin.uuid.Uuid
+import kotlinx.coroutines.flow.MutableStateFlow
+import org.junit.Test
+import org.junit.experimental.categories.Category
+
+@OptIn(ExperimentalTestApi::class, ExperimentalTime::class, ExperimentalUuidApi::class)
+@Category(UiTest::class)
+class NavigationViewModelTest {
+	@Test
+	fun opening_different_entries_uses_new_view_model() =
+		runComposeUiTest {
+			val entry1 = VoiceDiaryEntry(
+				id = Uuid.random(),
+				title = "Recording 1",
+				recordedAt = Clock.System.now(),
+				duration = Duration.ZERO,
+				transcriptionText = "Transcript 1",
+				transcriptionStatus = TranscriptionStatus.DONE,
+			)
+			val entry2 = VoiceDiaryEntry(
+				id = Uuid.random(),
+				title = "Recording 2",
+				recordedAt = Clock.System.now(),
+				duration = Duration.ZERO,
+				transcriptionText = "Transcript 2",
+				transcriptionStatus = TranscriptionStatus.DONE,
+			)
+			val client = NavigationFakeDiaryClient(listOf(entry1, entry2))
+			val recorder = mock<Recorder>()
+			every { recorder.isAvailable } returns false
+			val player1 = mock<Player>(mode = MockMode.autoUnit)
+			val player2 = mock<Player>(mode = MockMode.autoUnit)
+			every { player1.isAvailable } returns true
+			every { player2.isAvailable } returns true
+
+			setContent {
+				CompositionLocalProvider(
+					LocalLifecycleOwner provides NavigationFakeLifecycleOwner(),
+					LocalViewModelStoreOwner provides NavigationFakeViewModelStoreOwner(),
+				) {
+					MaterialTheme {
+						var selectedEntryId by remember { mutableStateOf<Uuid?>(null) }
+						if (selectedEntryId == null) {
+							MainScreen(
+								diaryClient = client,
+								recorder = recorder,
+								onEntryClick = { selectedEntryId = it.id },
+							)
+						} else {
+							val player =
+								if (selectedEntryId == entry1.id) player1 else player2
+							EntryDetailScreen(
+								diaryClient = client,
+								entryId = selectedEntryId!!,
+								onBack = { selectedEntryId = null },
+								player = player,
+								transcriber = null,
+							)
+						}
+					}
+				}
+			}
+
+			waitForIdle()
+
+			onNodeWithText("Recording 1", substring = false).performClick()
+			waitForIdle()
+			onNodeWithText("Transcript 1", substring = false).assertIsDisplayed()
+
+			onNodeWithText("Back", substring = false).performClick()
+			waitForIdle()
+			verify { player1.close() }
+
+			onNodeWithText("Recording 2", substring = false).performClick()
+			waitForIdle()
+			onNodeWithText("Transcript 2", substring = false).assertIsDisplayed()
+
+			onNodeWithText("Back", substring = false).performClick()
+			waitForIdle()
+			verify { player2.close() }
+		}
+}
+
+@OptIn(ExperimentalUuidApi::class, ExperimentalTime::class)
+private class NavigationFakeDiaryClient(
+	entries: List<VoiceDiaryEntry>,
+) : DiaryClient(baseUrl = "", httpClient = HttpClient()) {
+	private val _entries = MutableStateFlow(entries)
+	override val entries: MutableStateFlow<List<VoiceDiaryEntry>> get() = _entries
+
+	override suspend fun getAudio(id: Uuid): ByteArray = byteArrayOf(0)
+}
+
+private class NavigationFakeLifecycleOwner : LifecycleOwner {
+	private val registry = LifecycleRegistry(this).apply {
+		currentState = Lifecycle.State.RESUMED
+	}
+	override val lifecycle: Lifecycle get() = registry
+}
+
+private class NavigationFakeViewModelStoreOwner : ViewModelStoreOwner {
+	override val viewModelStore: ViewModelStore = ViewModelStore()
+}


### PR DESCRIPTION
## Summary
- scope EntryDetailViewModel to a screen-specific ViewModelStore and clear it on disposal to release the player
- verify detail navigation closes the previous entry's player when returning to the list

## Testing
- `./gradlew ktlintFormat`
- `./gradlew checkAgentsEnvironment`


------
https://chatgpt.com/codex/tasks/task_e_68b8a3d811448332ab2b854677e9ef6f