### PR TITLE
Configure Compose compiler stability for UUID

### DIFF
--- a/composeApp/build.gradle.kts
+++ b/composeApp/build.gradle.kts
@@ -36,10 +36,22 @@ kotlin {
 		@OptIn(ExperimentalKotlinGradlePluginApi::class)
 		compilerOptions {
 			jvmTarget.set(JvmTarget.JVM_11)
+			freeCompilerArgs.addAll(
+				"-P",
+				"plugin:androidx.compose.compiler.plugins.kotlin:stabilityConfigurationPath=${project.rootDir.absolutePath}/compose_compiler_config.conf",
+			)
 		}
 	}
 
-	jvm()
+	jvm {
+		@OptIn(ExperimentalKotlinGradlePluginApi::class)
+		compilerOptions {
+			freeCompilerArgs.addAll(
+				"-P",
+				"plugin:androidx.compose.compiler.plugins.kotlin:stabilityConfigurationPath=${project.rootDir.absolutePath}/compose_compiler_config.conf",
+			)
+		}
+	}
 
 	@OptIn(ExperimentalComposeLibrary::class)
 	sourceSets {

--- a/compose_compiler_config.conf
+++ b/compose_compiler_config.conf
@@ -1,0 +1,6 @@
+kotlin.uuid.Uuid
+java.util.UUID
+java.time.OffsetDateTime
+java.time.LocalDate
+java.time.ZoneOffset
+java.time.ZoneId


### PR DESCRIPTION
## Summary
- instruct Compose compiler to load custom stability configuration
- list UUID and common time classes as stable for Compose

## Testing
- `./gradlew ktlintFormat`
- `./gradlew checkAgentsEnvironment`
- `./gradlew :composeApp:compileDebugKotlin`


------
https://chatgpt.com/codex/tasks/task_e_68c0192967308332b56710aa102bb609