### PR TITLE
Annotate EntryDetailUiState as immutable

### DIFF
--- a/composeApp/src/commonMain/kotlin/de/lehrbaum/voiry/ui/EntryDetailViewModel.kt
+++ b/composeApp/src/commonMain/kotlin/de/lehrbaum/voiry/ui/EntryDetailViewModel.kt
@@ -1,5 +1,6 @@
 package de.lehrbaum.voiry.ui
 
+import androidx.compose.runtime.Immutable
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import de.lehrbaum.voiry.api.v1.DiaryClient
@@ -129,8 +130,12 @@ class EntryDetailViewModel(
 	}
 }
 
+@Immutable
 data class EntryDetailUiState(
 	val entry: VoiceDiaryEntry? = null,
+	/**
+	 * Audio data must not be mutated; the ByteArray is treated as immutable by convention.
+	 */
 	val audio: ByteArray? = null,
 	val isPlaying: Boolean = false,
 	val error: String? = null,


### PR DESCRIPTION
## Summary
- mark `EntryDetailUiState` with `@Immutable`
- document that its `ByteArray` must be treated as immutable

## Testing
- `./gradlew ktlintFormat`
- `./gradlew checkAgentsEnvironment`


------
https://chatgpt.com/codex/tasks/task_e_68c016c12fb083328a5a04eafb90ed49