### PR TITLE
Automate Compose compiler stability configuration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -123,3 +123,4 @@ frontendios/iosApp.xcodeproj/*
 /.idea/deploymentTargetSelector.xml
 /.idea/xcode.xml
 /.idea/kotlinc.xml
+

--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -1,0 +1,12 @@
+plugins {
+    `kotlin-dsl`
+}
+
+repositories {
+    mavenCentral()
+    google()
+}
+
+dependencies {
+    implementation("org.jetbrains.kotlin:kotlin-gradle-plugin-api:2.2.10")
+}

--- a/buildSrc/src/main/kotlin/MarkStable.kt
+++ b/buildSrc/src/main/kotlin/MarkStable.kt
@@ -1,0 +1,38 @@
+package buildsrc
+
+import org.gradle.api.Project
+import org.jetbrains.kotlin.gradle.dsl.KotlinJvmCompilerOptions
+import org.jetbrains.kotlin.gradle.tasks.KotlinCompilationTask
+
+/**
+ * Configures the Compose compiler to treat the provided classes as stable by generating
+ * a stability configuration file under the root build directory and wiring it into the
+ * compiler arguments for all Kotlin compilation tasks.
+ */
+fun KotlinJvmCompilerOptions.markBuiltInClassesAsStable(
+    project: Project,
+    stableClasses: List<String>,
+) {
+    val configFile = project.rootProject.layout.buildDirectory
+        .file("compose_compiler_config.conf").get().asFile
+
+    val task = project.rootProject.tasks.findByName("generateComposeStabilityConfig")
+        ?: project.rootProject.tasks.register("generateComposeStabilityConfig") {
+            inputs.property("stableClasses", stableClasses)
+            outputs.file(configFile)
+            doLast {
+                configFile.parentFile.mkdirs()
+                configFile.writeText(stableClasses.joinToString(System.lineSeparator()))
+            }
+            notCompatibleWithConfigurationCache("Task uses build script values")
+        }.get()
+
+    project.tasks.withType(KotlinCompilationTask::class.java).configureEach { dependsOn(task) }
+
+    freeCompilerArgs.addAll(
+        listOf(
+            "-P",
+            "plugin:androidx.compose.compiler.plugins.kotlin:stabilityConfigurationPath=${configFile.absolutePath}",
+        )
+    )
+}

--- a/composeApp/build.gradle.kts
+++ b/composeApp/build.gradle.kts
@@ -1,3 +1,4 @@
+import buildsrc.markBuiltInClassesAsStable
 import com.codingfeline.buildkonfig.compiler.FieldSpec.Type.STRING
 import java.util.Properties
 import org.gradle.api.tasks.testing.Test
@@ -23,6 +24,9 @@ val localProps = Properties().apply {
 }
 val backendUrl = localProps.getProperty("backendUrl") ?: "http://localhost:8888"
 
+// Classes treated as stable by the Compose compiler.
+val stableClasses = listOf("kotlin.uuid.Uuid")
+
 buildkonfig {
 	packageName = "de.lehrbaum.voiry"
 	exposeObjectWithName = "BuildKonfig"
@@ -36,10 +40,14 @@ kotlin {
 		@OptIn(ExperimentalKotlinGradlePluginApi::class)
 		compilerOptions {
 			jvmTarget.set(JvmTarget.JVM_11)
+			markBuiltInClassesAsStable(project, stableClasses)
 		}
 	}
 
-	jvm()
+	jvm {
+		@OptIn(ExperimentalKotlinGradlePluginApi::class)
+		compilerOptions { markBuiltInClassesAsStable(project, stableClasses) }
+	}
 
 	@OptIn(ExperimentalComposeLibrary::class)
 	sourceSets {


### PR DESCRIPTION
## Summary
- generate Compose compiler stability config in the root build directory
- expose stable class list via buildSrc extension and call it from the Compose app
- drop unused Java time/UUID entries and cleanup old ignore rule

## Testing
- `./gradlew ktlintFormat`
- `./gradlew checkAgentsEnvironment --no-configuration-cache`
- `./gradlew :composeApp:compileDebugKotlin`


------
https://chatgpt.com/codex/tasks/task_e_68c0192967308332b56710aa102bb609