### PR TITLE
docs: clarify wait strategy for Compose UI tests

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,6 +4,7 @@
 - Client-only logic must live in the `composeApp` module.
 - Server-only code must reside in the `server` module.
 - New features should include tests, but do not write tests for log output.
+- Compose UI tests should not use `waitForIdle`; prefer `waitUntil` or one of its variants.
 
 Before commit please run `./gradlew ktlintFormat`
 To verify changes run `./gradlew checkAgentsEnvironment`


### PR DESCRIPTION
## Summary
- clarify that Compose UI tests should use `waitUntil` rather than `waitForIdle`

## Testing
- `./gradlew ktlintFormat`
- `./gradlew checkAgentsEnvironment`


------
https://chatgpt.com/codex/tasks/task_e_68c05b8b0cac8332ac33c66ff3b7bf5a