### PR TITLE
Defer entry audio downloads until needed

### DIFF
--- a/composeApp/build.gradle.kts
+++ b/composeApp/build.gradle.kts
@@ -79,6 +79,7 @@ kotlin {
 		}
 		commonTest.dependencies {
 			implementation(libs.kotlin.test)
+			implementation(libs.kotlinx.coroutinesTest)
 		}
 		jvmMain.dependencies {
 			implementation(compose.desktop.currentOs)

--- a/composeApp/src/commonMain/kotlin/de/lehrbaum/voiry/ui/EntryDetailScreen.kt
+++ b/composeApp/src/commonMain/kotlin/de/lehrbaum/voiry/ui/EntryDetailScreen.kt
@@ -125,12 +125,10 @@ fun EntryDetailScreen(
 				horizontalArrangement = Arrangement.spacedBy(8.dp),
 				verticalArrangement = Arrangement.spacedBy(8.dp),
 			) {
-				state.audio?.let {
-					TextButton(
-						onClick = { viewModel.togglePlayback() },
-					) {
-						Text(if (state.isPlaying) "Stop" else "Play")
-					}
+				TextButton(
+					onClick = { viewModel.togglePlayback() },
+				) {
+					Text(if (state.isPlaying) "Stop" else "Play")
 				}
 				TranscribeButtonWithProgress(
 					transcriber = viewModel.transcriber,

--- a/composeApp/src/commonTest/kotlin/de/lehrbaum/voiry/ui/EntryDetailViewModelTest.kt
+++ b/composeApp/src/commonTest/kotlin/de/lehrbaum/voiry/ui/EntryDetailViewModelTest.kt
@@ -1,0 +1,84 @@
+package de.lehrbaum.voiry.ui
+
+import de.lehrbaum.voiry.api.v1.DiaryClient
+import de.lehrbaum.voiry.api.v1.TranscriptionStatus
+import de.lehrbaum.voiry.api.v1.UpdateTranscriptionRequest
+import de.lehrbaum.voiry.api.v1.VoiceDiaryEntry
+import de.lehrbaum.voiry.audio.AudioCache
+import de.lehrbaum.voiry.audio.Player
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.time.Duration
+import kotlin.time.ExperimentalTime
+import kotlin.time.Instant
+import kotlin.uuid.ExperimentalUuidApi
+import kotlin.uuid.Uuid
+import kotlinx.collections.immutable.PersistentList
+import kotlinx.collections.immutable.persistentListOf
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.runTest
+
+@OptIn(ExperimentalUuidApi::class, ExperimentalTime::class, ExperimentalCoroutinesApi::class)
+class EntryDetailViewModelTest : MainDispatcherTest by MainDispatcherRule() {
+	@Test
+	fun `does not download audio until needed`() =
+		runTest {
+			val id = Uuid.random()
+			val diaryClient = FakeDiaryClient(id)
+			EntryDetailViewModel(diaryClient, id, FakePlayer(), null)
+			advanceUntilIdle()
+			assertEquals(0, diaryClient.getAudioCalls)
+		}
+
+	@Test
+	fun `downloads audio on playback`() =
+		runTest {
+			val id = Uuid.random()
+			val diaryClient = FakeDiaryClient(id)
+			val player = FakePlayer()
+			val viewModel = EntryDetailViewModel(diaryClient, id, player, null)
+			advanceUntilIdle()
+			viewModel.togglePlayback()
+			advanceUntilIdle()
+			assertEquals(1, diaryClient.getAudioCalls)
+			assertEquals(1, player.playCalls)
+		}
+
+	private class FakeDiaryClient(id: Uuid) : DiaryClient("test", audioCache = AudioCache(".")) {
+		private val entry = VoiceDiaryEntry(
+			id = id,
+			title = "title",
+			recordedAt = Instant.fromEpochMilliseconds(0),
+			duration = Duration.ZERO,
+			transcriptionStatus = TranscriptionStatus.NONE,
+		)
+		var getAudioCalls = 0
+		override val entries: StateFlow<PersistentList<VoiceDiaryEntry>> =
+			MutableStateFlow(persistentListOf(entry))
+
+		override fun entryFlow(id: Uuid): StateFlow<VoiceDiaryEntry?> = MutableStateFlow(entry)
+
+		override suspend fun getAudio(id: Uuid): ByteArray {
+			getAudioCalls++
+			return byteArrayOf(1)
+		}
+
+		override suspend fun updateTranscription(id: Uuid, request: UpdateTranscriptionRequest) {}
+	}
+
+	private class FakePlayer : Player {
+		var playCalls = 0
+		override val isAvailable: Boolean = true
+
+		override fun play(audio: ByteArray) {
+			playCalls++
+		}
+
+		override fun stop() {}
+
+		override fun close() {}
+	}
+}

--- a/composeApp/src/commonTest/kotlin/de/lehrbaum/voiry/ui/MainDispatcherRule.kt
+++ b/composeApp/src/commonTest/kotlin/de/lehrbaum/voiry/ui/MainDispatcherRule.kt
@@ -1,0 +1,21 @@
+package de.lehrbaum.voiry.ui
+
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.TestDispatcher
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.setMain
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class MainDispatcherRule(
+	private val dispatcher: TestDispatcher = StandardTestDispatcher(),
+) : MainDispatcherTest {
+	override fun setup() {
+		Dispatchers.setMain(dispatcher)
+	}
+
+	override fun tearDown() {
+		Dispatchers.resetMain()
+	}
+}

--- a/composeApp/src/commonTest/kotlin/de/lehrbaum/voiry/ui/MainDispatcherTest.kt
+++ b/composeApp/src/commonTest/kotlin/de/lehrbaum/voiry/ui/MainDispatcherTest.kt
@@ -1,0 +1,12 @@
+package de.lehrbaum.voiry.ui
+
+import kotlin.test.AfterTest
+import kotlin.test.BeforeTest
+
+interface MainDispatcherTest {
+	@BeforeTest
+	fun setup()
+
+	@AfterTest
+	fun tearDown()
+}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -34,6 +34,7 @@ androidx-lifecycle-viewmodelCompose = { module = "org.jetbrains.androidx.lifecyc
 androidx-lifecycle-runtimeCompose = { module = "org.jetbrains.androidx.lifecycle:lifecycle-runtime-compose", version.ref = "androidx-lifecycle" }
 kotlinx-coroutinesSwing = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-swing", version.ref = "kotlinx-coroutines" }
 kotlinx-coroutinesCore = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-core", version.ref = "kotlinx-coroutines" }
+kotlinx-coroutinesTest = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-test", version.ref = "kotlinx-coroutines" }
 kotlinx-io-core = { module = "org.jetbrains.kotlinx:kotlinx-io-core", version.ref = "kotlinxIoCore" }
 logback = { module = "ch.qos.logback:logback-classic", version.ref = "logback" }
 ktor-serverCore = { module = "io.ktor:ktor-server-core-jvm", version.ref = "ktor" }


### PR DESCRIPTION
## Summary
- avoid prefetching entry audio
- load audio lazily when playing or transcribing
- test EntryDetailViewModel only downloads audio on demand
- replace flaky delay-based tests with deterministic coroutine testing utilities

## Testing
- `./gradlew ktlintFormat`
- `./gradlew checkAgentsEnvironment`


------
https://chatgpt.com/codex/tasks/task_e_68c19fc9cdb88332abefe28505cf312f