### PR TITLE
Refactor server routing and remove magic number

### DIFF
--- a/server/src/main/kotlin/de/lehrbaum/voiry/Application.kt
+++ b/server/src/main/kotlin/de/lehrbaum/voiry/Application.kt
@@ -8,9 +8,11 @@ import de.lehrbaum.voiry.api.v1.VoiceDiaryEntry
 import io.github.aakira.napier.Napier
 import io.ktor.http.ContentType
 import io.ktor.http.HttpStatusCode
+import io.ktor.http.content.PartData
 import io.ktor.http.content.forEachPart
 import io.ktor.serialization.kotlinx.json.json
 import io.ktor.server.application.Application
+import io.ktor.server.application.ApplicationCall
 import io.ktor.server.application.install
 import io.ktor.server.engine.embeddedServer
 import io.ktor.server.netty.Netty
@@ -19,6 +21,7 @@ import io.ktor.server.request.receive
 import io.ktor.server.request.receiveMultipart
 import io.ktor.server.response.respond
 import io.ktor.server.response.respondBytes
+import io.ktor.server.routing.Route
 import io.ktor.server.routing.delete
 import io.ktor.server.routing.get
 import io.ktor.server.routing.post
@@ -47,68 +50,98 @@ fun Application.module(service: DiaryService = runBlocking { DiaryServiceImpl.cr
 	install(ContentNegotiation) { json() }
 	install(SSE)
 
+	configureHealthCheck()
+	configureV1Routes(service)
+}
+
+private fun Application.configureHealthCheck() {
 	routing {
-		get("/health") {
-			call.respond(HttpStatusCode.OK)
-		}
+		get("/health") { call.respond(HttpStatusCode.OK) }
+	}
+}
+
+private fun Application.configureV1Routes(service: DiaryService) {
+	routing {
 		route("/v1") {
-			sse("/entries") {
-				val json = Json
-				service.eventFlow().collect { event: DiaryEvent ->
-					val data = json.encodeToString(event)
-					send(ServerSentEvent(data = data))
-				}
-			}
-
-			post("/entries") {
-				val multipart = call.receiveMultipart()
-				var metadata: VoiceDiaryEntry? = null
-				var audio: ByteArray? = null
-				multipart.forEachPart { part ->
-					when (part) {
-						is io.ktor.http.content.PartData.FormItem -> if (part.name == "metadata") {
-							metadata = Json.decodeFromString<VoiceDiaryEntry>(part.value)
-						}
-						is io.ktor.http.content.PartData.FileItem -> if (part.name == "audio") {
-							audio = part.provider().readRemaining().readByteArray()
-						}
-						else -> {}
-					}
-					part.dispose()
-				}
-				if (metadata == null || audio == null) {
-					call.respond(HttpStatusCode.BadRequest)
-				} else {
-					service.addEntry(metadata, audio)
-					call.respond(metadata)
-				}
-			}
-
-			put("/entries/{id}/transcription") {
-				val idParam = call.parameters["id"] ?: return@put call.respond(HttpStatusCode.BadRequest)
-				val id = Uuid.parse(idParam)
-				val req = call.receive<UpdateTranscriptionRequest>()
-				service.updateTranscription(id, req.transcriptionText, req.transcriptionStatus, req.transcriptionUpdatedAt)
-				call.respond(HttpStatusCode.OK)
-			}
-
-			delete("/entries/{id}") {
-				val idParam = call.parameters["id"] ?: return@delete call.respond(HttpStatusCode.BadRequest)
-				val id = Uuid.parse(idParam)
-				service.deleteEntry(id)
-				call.respond(HttpStatusCode.NoContent)
-			}
-
-			get("/entries/{id}/audio") {
-				val idParam = call.parameters["id"] ?: return@get call.respond(HttpStatusCode.BadRequest)
-				val id = Uuid.parse(idParam)
-				val audio = service.getAudio(id)
-				if (audio == null) {
-					call.respond(HttpStatusCode.NotFound)
-				} else {
-					call.respondBytes(audio, ContentType("audio", "wav"))
-				}
-			}
+			entriesEvents(service)
+			postEntry(service)
+			updateTranscription(service)
+			deleteEntry(service)
+			entryAudio(service)
 		}
 	}
+}
+
+private fun Route.entriesEvents(service: DiaryService) {
+	sse("/entries") {
+		val json = Json
+		service.eventFlow().collect { event: DiaryEvent ->
+			val data = json.encodeToString(event)
+			send(ServerSentEvent(data = data))
+		}
+	}
+}
+
+private fun Route.postEntry(service: DiaryService) {
+	post("/entries") {
+		val entry = call.receiveEntryMultipart()
+		if (entry == null) {
+			call.respond(HttpStatusCode.BadRequest)
+		} else {
+			val (metadata, audio) = entry
+			service.addEntry(metadata, audio)
+			call.respond(metadata)
+		}
+	}
+}
+
+private fun Route.updateTranscription(service: DiaryService) {
+	put("/entries/{id}/transcription") {
+		val idParam = call.parameters["id"] ?: return@put call.respond(HttpStatusCode.BadRequest)
+		val id = Uuid.parse(idParam)
+		val req = call.receive<UpdateTranscriptionRequest>()
+		service.updateTranscription(id, req.transcriptionText, req.transcriptionStatus, req.transcriptionUpdatedAt)
+		call.respond(HttpStatusCode.OK)
+	}
+}
+
+private fun Route.deleteEntry(service: DiaryService) {
+	delete("/entries/{id}") {
+		val idParam = call.parameters["id"] ?: return@delete call.respond(HttpStatusCode.BadRequest)
+		val id = Uuid.parse(idParam)
+		service.deleteEntry(id)
+		call.respond(HttpStatusCode.NoContent)
+	}
+}
+
+private fun Route.entryAudio(service: DiaryService) {
+	get("/entries/{id}/audio") {
+		val idParam = call.parameters["id"] ?: return@get call.respond(HttpStatusCode.BadRequest)
+		val id = Uuid.parse(idParam)
+		val audio = service.getAudio(id)
+		if (audio == null) {
+			call.respond(HttpStatusCode.NotFound)
+		} else {
+			call.respondBytes(audio, ContentType("audio", "wav"))
+		}
+	}
+}
+
+private suspend fun ApplicationCall.receiveEntryMultipart(): Pair<VoiceDiaryEntry, ByteArray>? {
+	val multipart = receiveMultipart()
+	var metadata: VoiceDiaryEntry? = null
+	var audio: ByteArray? = null
+	multipart.forEachPart { part ->
+		when (part) {
+			is PartData.FormItem -> if (part.name == "metadata") {
+				metadata = Json.decodeFromString<VoiceDiaryEntry>(part.value)
+			}
+			is PartData.FileItem -> if (part.name == "audio") {
+				audio = part.provider().readRemaining().readByteArray()
+			}
+			else -> {}
+		}
+		part.dispose()
+	}
+	return if (metadata != null && audio != null) metadata!! to audio!! else null
 }

--- a/server/src/main/kotlin/de/lehrbaum/voiry/DiaryRepository.kt
+++ b/server/src/main/kotlin/de/lehrbaum/voiry/DiaryRepository.kt
@@ -25,6 +25,8 @@ import org.jetbrains.exposed.sql.transactions.experimental.newSuspendedTransacti
 import org.jetbrains.exposed.sql.transactions.transaction
 import org.jetbrains.exposed.sql.update
 
+private const val STATUS_NAME_MAX_LENGTH = 20 // Maximum TranscriptionStatus name length
+
 /**
  * Repository handling persistence of diary entries and their audio files.
  */
@@ -46,7 +48,11 @@ class DiaryRepository(private val baseDir: Path) {
 		val recordedAt = long("recorded_at")
 		val duration = long("duration_ms")
 		val transcriptionText = text("transcription_text").nullable()
-		val transcriptionStatus = enumerationByName("transcription_status", 20, TranscriptionStatus::class)
+		val transcriptionStatus = enumerationByName(
+			"transcription_status",
+			STATUS_NAME_MAX_LENGTH,
+			TranscriptionStatus::class,
+		)
 		val transcriptionUpdatedAt = long("transcription_updated_at").nullable()
 		override val primaryKey = PrimaryKey(id)
 	}


### PR DESCRIPTION
## Summary
- extract server routing into helpers for health and entry APIs
- replace transcription status width magic number with named constant

## Testing
- `./gradlew ktlintFormat`
- `./gradlew detekt`
- `./gradlew checkAgentsEnvironment`


------
https://chatgpt.com/codex/tasks/task_e_68c3ff6d6db88332a9720790aee19859