### PR TITLE
Ensure coroutine cancellation propagates

### DIFF
--- a/composeApp/src/commonMain/kotlin/de/lehrbaum/voiry/RunSuspendCatching.kt
+++ b/composeApp/src/commonMain/kotlin/de/lehrbaum/voiry/RunSuspendCatching.kt
@@ -1,0 +1,12 @@
+package de.lehrbaum.voiry
+
+import kotlinx.coroutines.CancellationException
+
+inline fun <T> runSuspendCatching(block: () -> T): Result<T> =
+	try {
+		Result.success(block())
+	} catch (e: CancellationException) {
+		throw e
+	} catch (e: Throwable) {
+		Result.failure(e)
+	}

--- a/composeApp/src/commonMain/kotlin/de/lehrbaum/voiry/ui/EntryDetailViewModel.kt
+++ b/composeApp/src/commonMain/kotlin/de/lehrbaum/voiry/ui/EntryDetailViewModel.kt
@@ -11,6 +11,7 @@ import de.lehrbaum.voiry.audio.Player
 import de.lehrbaum.voiry.audio.Transcriber
 import de.lehrbaum.voiry.audio.platformPlayer
 import de.lehrbaum.voiry.audio.platformTranscriber
+import de.lehrbaum.voiry.runSuspendCatching
 import java.io.Closeable
 import kotlin.time.Clock
 import kotlin.time.ExperimentalTime
@@ -93,7 +94,7 @@ class EntryDetailViewModel(
 		val edited = _uiState.value.editedText
 		viewModelScope.launch {
 			_uiState.update { it.copy(isSaving = true) }
-			runCatching {
+			runSuspendCatching {
 				diaryClient.updateTranscription(
 					entry.id,
 					UpdateTranscriptionRequest(
@@ -136,7 +137,7 @@ class EntryDetailViewModel(
 
 	private fun downloadAudio(onSuccess: (ByteArray) -> Unit) {
 		viewModelScope.launch {
-			runCatching { diaryClient.getAudio(entryId) }
+			runSuspendCatching { diaryClient.getAudio(entryId) }
 				.onSuccess { data ->
 					_uiState.update { it.copy(audio = data) }
 					onSuccess(data)
@@ -146,7 +147,7 @@ class EntryDetailViewModel(
 
 	fun delete(onSuccess: () -> Unit) {
 		viewModelScope.launch {
-			runCatching { diaryClient.deleteEntry(entryId) }
+			runSuspendCatching { diaryClient.deleteEntry(entryId) }
 				.onSuccess { onSuccess() }
 				.onFailure { e -> _uiState.update { it.copy(error = e.message) } }
 		}
@@ -174,7 +175,7 @@ private suspend fun transcribeEntry(
 	entryId: Uuid,
 	audio: ByteArray,
 ): Result<Unit> =
-	runCatching {
+	runSuspendCatching {
 		val buffer = Buffer().apply { write(audio) }
 		val text = transcriber.transcribe(buffer)
 		diaryClient.updateTranscription(


### PR DESCRIPTION
## Summary
- Add `runSuspendCatching` helper that rethrows `CancellationException` and wraps other failures.
- Use the helper in `MainViewModel` when creating, deleting, and transcribing entries.
- Apply the same pattern in `EntryDetailViewModel` for editing, audio loading, deletion, and transcription.

## Testing
- `./gradlew ktlintFormat`
- `./gradlew checkAgentsEnvironment`


------
https://chatgpt.com/codex/tasks/task_e_68c4254b12e083329308ecb5a601d2dc