### PR TITLE
Add Room-based offline cache

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -9,6 +9,8 @@ plugins {
 	alias(libs.plugins.kotlinJvm) apply false
 	alias(libs.plugins.kotlinMultiplatform) apply false
 	alias(libs.plugins.mokkery) apply false
+	alias(libs.plugins.ksp) apply false
+	alias(libs.plugins.androidx.room) apply false
 	alias(libs.plugins.ktlint)
 	alias(libs.plugins.detekt)
 }

--- a/composeApp/src/commonMain/kotlin/de/lehrbaum/voiry/offline/EntryDao.kt
+++ b/composeApp/src/commonMain/kotlin/de/lehrbaum/voiry/offline/EntryDao.kt
@@ -1,0 +1,25 @@
+package de.lehrbaum.voiry.offline
+
+import androidx.room.Dao
+import androidx.room.Insert
+import androidx.room.OnConflictStrategy
+import androidx.room.Query
+import kotlinx.coroutines.flow.Flow
+
+@Dao
+interface EntryDao {
+    @Query("SELECT * FROM entries")
+    fun observeAll(): Flow<List<EntryEntity>>
+
+    @Insert(onConflict = OnConflictStrategy.REPLACE)
+    suspend fun upsert(entry: EntryEntity)
+
+    @Insert(onConflict = OnConflictStrategy.REPLACE)
+    suspend fun upsertAll(entries: List<EntryEntity>)
+
+    @Query("DELETE FROM entries WHERE id = :id")
+    suspend fun deleteById(id: String)
+
+    @Query("DELETE FROM entries")
+    suspend fun clear()
+}

--- a/composeApp/src/commonMain/kotlin/de/lehrbaum/voiry/offline/EntryEntity.kt
+++ b/composeApp/src/commonMain/kotlin/de/lehrbaum/voiry/offline/EntryEntity.kt
@@ -1,0 +1,15 @@
+package de.lehrbaum.voiry.offline
+
+import androidx.room.Entity
+import androidx.room.PrimaryKey
+
+@Entity(tableName = "entries")
+data class EntryEntity(
+    @PrimaryKey val id: String,
+    val title: String,
+    val recordedAt: Long,
+    val durationMillis: Long,
+    val transcriptionText: String?,
+    val transcriptionStatus: String,
+    val transcriptionUpdatedAt: Long?,
+)

--- a/composeApp/src/commonMain/kotlin/de/lehrbaum/voiry/offline/OfflineDatabase.kt
+++ b/composeApp/src/commonMain/kotlin/de/lehrbaum/voiry/offline/OfflineDatabase.kt
@@ -1,0 +1,22 @@
+package de.lehrbaum.voiry.offline
+
+import androidx.room.ConstructedBy
+import androidx.room.Database
+import androidx.room.RoomDatabase
+import androidx.room.RoomDatabaseConstructor
+
+@Database(
+    entities = [EntryEntity::class, PendingEventEntity::class],
+    version = 1,
+    exportSchema = false,
+)
+@ConstructedBy(OfflineDatabaseConstructor::class)
+abstract class OfflineDatabase : RoomDatabase() {
+    abstract fun entryDao(): EntryDao
+    abstract fun pendingEventDao(): PendingEventDao
+}
+
+@Suppress("KotlinNoActualForExpect")
+expect object OfflineDatabaseConstructor : RoomDatabaseConstructor<OfflineDatabase> {
+    override fun initialize(): OfflineDatabase
+}

--- a/composeApp/src/commonMain/kotlin/de/lehrbaum/voiry/offline/PendingEventDao.kt
+++ b/composeApp/src/commonMain/kotlin/de/lehrbaum/voiry/offline/PendingEventDao.kt
@@ -1,0 +1,18 @@
+package de.lehrbaum.voiry.offline
+
+import androidx.room.Dao
+import androidx.room.Insert
+import androidx.room.Query
+import kotlinx.coroutines.flow.Flow
+
+@Dao
+interface PendingEventDao {
+    @Query("SELECT * FROM pending_events ORDER BY id ASC")
+    fun observeAll(): Flow<List<PendingEventEntity>>
+
+    @Insert
+    suspend fun enqueue(event: PendingEventEntity): Long
+
+    @Query("DELETE FROM pending_events WHERE id = :id")
+    suspend fun remove(id: Long)
+}

--- a/composeApp/src/commonMain/kotlin/de/lehrbaum/voiry/offline/PendingEventEntity.kt
+++ b/composeApp/src/commonMain/kotlin/de/lehrbaum/voiry/offline/PendingEventEntity.kt
@@ -1,0 +1,20 @@
+package de.lehrbaum.voiry.offline
+
+import androidx.room.ColumnInfo
+import androidx.room.Entity
+import androidx.room.PrimaryKey
+
+@Entity(tableName = "pending_events")
+data class PendingEventEntity(
+    @PrimaryKey(autoGenerate = true) val id: Long = 0,
+    val type: PendingEventType,
+    @ColumnInfo(name = "entry_id") val entryId: String,
+    val payload: String,
+    @ColumnInfo(name = "queued_at") val queuedAt: Long,
+)
+
+enum class PendingEventType {
+    CREATE,
+    UPDATE_TRANSCRIPTION,
+    DELETE,
+}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -9,6 +9,9 @@ composeHotReload = "1.0.0-beta06"
 composeMultiplatform = "1.8.2"
 junit = "4.13.2"
 kotlin = "2.2.20"
+ksp = "2.2.20-2.0.3"
+kotlinx-sqlite = "2.6.0"
+room = "2.8.0"
 kotlinx-coroutines = "1.10.2"
 kotlinxIoCore = "0.8.0"
 ktor = "3.2.3"
@@ -57,6 +60,10 @@ appdirs = { module = "ca.gosyer:kotlin-multiplatform-appdirs", version.ref = "ap
 lexilabs-basic-sound = { module = "app.lexilabs.basic:basic-sound", version.ref = "lexilabs-basic" }
 kotlinx-datetime = { module = "org.jetbrains.kotlinx:kotlinx-datetime", version.ref = "kotlinx-datetime" }
 kotlinx-collections-immutable = { module = "org.jetbrains.kotlinx:kotlinx-collections-immutable", version.ref = "kotlinx-collections-immutable" }
+androidx-sqlite-bundled = { module = "androidx.sqlite:sqlite-bundled", version.ref = "kotlinx-sqlite" }
+androidx-room-runtime = { module = "androidx.room:room-runtime", version.ref = "room" }
+androidx-room-compiler = { module = "androidx.room:room-compiler", version.ref = "room" }
+androidx-room-sqlite-wrapper = { module = "androidx.room:room-sqlite-wrapper", version.ref = "room" }
 
 [plugins]
 androidApplication = { id = "com.android.application", version.ref = "agp" }
@@ -72,3 +79,5 @@ detekt = { id = "io.gitlab.arturbosch.detekt", version.ref = "detekt" }
 mokkery = { id = "dev.mokkery", version.ref = "mokkery" }
 kotlinSerialization = { id = "org.jetbrains.kotlin.plugin.serialization", version.ref = "kotlin" }
 buildkonfig = { id = "com.codingfeline.buildkonfig", version.ref = "buildkonfig" }
+ksp = { id = "com.google.devtools.ksp", version.ref = "ksp" }
+androidx-room = { id = "androidx.room", version.ref = "room" }


### PR DESCRIPTION
## Summary
- integrate Room dependencies and plugins for offline database
- introduce entities and DAOs for cached entries and pending events
- configure Room schema generation and KSP for multiplatform targets

## Testing
- `./gradlew ktlintFormat` *(fails: Task ':composeApp:kspDebugKotlinAndroid' uses outputs of other tasks without declaring dependency)*
- `./gradlew checkAgentsEnvironment` *(fails: Task ':composeApp:kspKotlinJvm' uses outputs of other tasks without declaring dependency)*

------
https://chatgpt.com/codex/tasks/task_e_68c66aad95488332a72fec8af8f0c928