### PR TITLE
Add delete confirmation dialog

### DIFF
--- a/composeApp/src/commonMain/kotlin/de/lehrbaum/voiry/ui/EntryDetailScreen.kt
+++ b/composeApp/src/commonMain/kotlin/de/lehrbaum/voiry/ui/EntryDetailScreen.kt
@@ -8,6 +8,7 @@ import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.OutlinedTextField
@@ -18,7 +19,9 @@ import androidx.compose.material3.TopAppBar
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.ViewModelStore
@@ -57,6 +60,8 @@ fun EntryDetailScreen(
 		) { EntryDetailViewModel(diaryClient, entryId, player, transcriber) }
 	val state by viewModel.uiState.collectAsStateWithLifecycle()
 	val entry = state.entry ?: return
+
+	var showDeleteDialog by remember { mutableStateOf(false) }
 
 	Scaffold(
 		topBar = {
@@ -134,15 +139,29 @@ fun EntryDetailScreen(
 					transcriber = viewModel.transcriber,
 					onTranscribe = { viewModel.transcribe() },
 				)
-				TextButton(
-					onClick = { viewModel.delete(onBack) },
-				) {
-					Text("Delete")
-				}
+				TextButton(onClick = { showDeleteDialog = true }) { Text("Delete") }
 			}
 			if (state.error != null) {
 				Text("Error: ${state.error}")
 			}
 		}
+	}
+	if (showDeleteDialog) {
+		AlertDialog(
+			onDismissRequest = { showDeleteDialog = false },
+			title = { Text("Delete entry?") },
+			text = { Text("Are you sure you want to delete this entry?") },
+			confirmButton = {
+				TextButton(
+					onClick = {
+						showDeleteDialog = false
+						viewModel.delete(onBack)
+					},
+				) { Text("Delete") }
+			},
+			dismissButton = {
+				TextButton(onClick = { showDeleteDialog = false }) { Text("Cancel") }
+			},
+		)
 	}
 }

--- a/composeApp/src/commonMain/kotlin/de/lehrbaum/voiry/ui/MainScreen.kt
+++ b/composeApp/src/commonMain/kotlin/de/lehrbaum/voiry/ui/MainScreen.kt
@@ -25,7 +25,9 @@ import androidx.compose.material3.TextField
 import androidx.compose.material3.TopAppBar
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
@@ -161,6 +163,7 @@ private fun EntryRow(
 ) {
 	val onDeleteClick = remember(entry.id, onDelete) { { onDelete(entry) } }
 	val onTranscribeClick = remember(entry.id, onTranscribe) { { onTranscribe(entry) } }
+	var showDeleteDialog by remember { mutableStateOf(false) }
 	ListItem(
 		modifier = Modifier.fillMaxWidth().clickable { onClick() },
 		headlineContent = { Text(entry.title) },
@@ -173,11 +176,29 @@ private fun EntryRow(
 					transcriber = transcriber,
 					onTranscribe = onTranscribeClick,
 				)
-				TextButton(onClick = onDeleteClick) { Text("Delete") }
+				TextButton(onClick = { showDeleteDialog = true }) { Text("Delete") }
 			}
 		},
 	)
 	HorizontalDivider()
+	if (showDeleteDialog) {
+		AlertDialog(
+			onDismissRequest = { showDeleteDialog = false },
+			title = { Text("Delete entry?") },
+			text = { Text("Are you sure you want to delete this entry?") },
+			confirmButton = {
+				TextButton(
+					onClick = {
+						showDeleteDialog = false
+						onDeleteClick()
+					},
+				) { Text("Delete") }
+			},
+			dismissButton = {
+				TextButton(onClick = { showDeleteDialog = false }) { Text("Cancel") }
+			},
+		)
+	}
 }
 
 @Composable

--- a/composeApp/src/jvmTest/kotlin/de/lehrbaum/voiry/ui/EntryDetailScreenTest.kt
+++ b/composeApp/src/jvmTest/kotlin/de/lehrbaum/voiry/ui/EntryDetailScreenTest.kt
@@ -9,6 +9,7 @@ import androidx.compose.ui.test.hasSetTextAction
 import androidx.compose.ui.test.hasText
 import androidx.compose.ui.test.isNotEnabled
 import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.onAllNodesWithText
 import androidx.compose.ui.test.performClick
 import androidx.compose.ui.test.performTextClearance
 import androidx.compose.ui.test.performTextInput
@@ -219,8 +220,9 @@ class EntryDetailScreenTest {
 			}
 
 			waitUntilAtLeastOneExists(hasText("Delete"))
-
 			onNodeWithText("Delete").performClick()
+			waitUntilAtLeastOneExists(hasText("Delete entry?"))
+			onAllNodesWithText("Delete")[1].performClick()
 			waitUntilDoesNotExist(hasText("Delete"))
 			assert(backCalled)
 			assert(clientMock.entries.value.isEmpty())
@@ -261,8 +263,9 @@ class EntryDetailScreenTest {
 			}
 
 			waitUntilAtLeastOneExists(hasText("Delete"))
-
 			onNodeWithText("Delete").performClick()
+			waitUntilAtLeastOneExists(hasText("Delete entry?"))
+			onAllNodesWithText("Delete")[1].performClick()
 			waitUntilAtLeastOneExists(hasText("Error: fail delete"))
 			assert(!backCalled)
 			assert(clientMock.entries.value.isNotEmpty())

--- a/composeApp/src/jvmTest/kotlin/de/lehrbaum/voiry/ui/MainScreenTest.kt
+++ b/composeApp/src/jvmTest/kotlin/de/lehrbaum/voiry/ui/MainScreenTest.kt
@@ -234,6 +234,8 @@ class MainScreenTest {
 			waitUntilAtLeastOneExists(hasText("Recording 1"))
 
 			onAllNodesWithText("Delete")[0].performClick()
+			waitUntilAtLeastOneExists(hasText("Delete entry?"))
+			onAllNodesWithText("Delete")[1].performClick()
 			waitUntilDoesNotExist(hasText("Recording 1"))
 		}
 


### PR DESCRIPTION
## Summary
- add delete confirmation dialog on entry details
- add delete confirmation dialog on main entry list
- adjust tests for delete confirmations

## Testing
- `./gradlew ktlintFormat`
- `./gradlew checkAgentsEnvironment`


------
https://chatgpt.com/codex/tasks/task_e_68c68d470dc483329062517cd8355db2