### PR TITLE
Add Android UI instrumented test support

### DIFF
--- a/composeApp/build.gradle.kts
+++ b/composeApp/build.gradle.kts
@@ -1,6 +1,7 @@
 import buildsrc.markBuiltInClassesAsStable
 import com.codingfeline.buildkonfig.compiler.FieldSpec.Type.STRING
 import java.util.Properties
+import org.jetbrains.compose.ComposePlugin
 import org.jetbrains.compose.ExperimentalComposeLibrary
 import org.jetbrains.compose.desktop.application.dsl.TargetFormat
 import org.jetbrains.kotlin.gradle.ExperimentalKotlinGradlePluginApi
@@ -97,6 +98,10 @@ kotlin {
 			implementation(libs.logback)
 			implementation(libs.mokkery.runtime)
 		}
+		androidInstrumentedTest.dependencies {
+			implementation(compose.uiTest)
+			implementation(libs.androidx.test.ext.junit)
+		}
 	}
 }
 
@@ -144,9 +149,14 @@ composeCompiler {
 	metricsDestination = layout.buildDirectory.dir("compose_compiler")
 }
 
+@OptIn(ExperimentalComposeLibrary::class)
 dependencies {
 	debugImplementation(compose.uiTooling)
+	debugImplementation(compose.uiTestManifest)
 }
+
+val ComposePlugin.Dependencies.uiTestManifest
+	get() = "androidx.compose.ui:ui-test-manifest"
 
 compose.desktop {
 	application {

--- a/composeApp/src/androidInstrumentedTest/kotlin/de/lehrbaum/voiry/MainActivityTest.kt
+++ b/composeApp/src/androidInstrumentedTest/kotlin/de/lehrbaum/voiry/MainActivityTest.kt
@@ -1,0 +1,17 @@
+package de.lehrbaum.voiry
+
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.junit4.createAndroidComposeRule
+import androidx.compose.ui.test.onNodeWithText
+import org.junit.Rule
+import org.junit.Test
+
+class MainActivityTest {
+	@get:Rule
+	val composeTestRule = createAndroidComposeRule<MainActivity>()
+
+	@Test
+	fun appBarTitleDisplayed() {
+		composeTestRule.onNodeWithText("Voice Diary").assertIsDisplayed()
+	}
+}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -38,6 +38,7 @@ kotlinx-coroutinesCore = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-co
 kotlinx-coroutinesTest = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-test", version.ref = "kotlinx-coroutines" }
 kotlinx-io-core = { module = "org.jetbrains.kotlinx:kotlinx-io-core", version.ref = "kotlinxIoCore" }
 logback = { module = "ch.qos.logback:logback-classic", version.ref = "logback" }
+androidx-test-ext-junit = { module = "androidx.test.ext:junit", version = "1.2.1" }
 ktor-serverCore = { module = "io.ktor:ktor-server-core-jvm", version.ref = "ktor" }
 ktor-serverNetty = { module = "io.ktor:ktor-server-netty-jvm", version.ref = "ktor" }
 ktor-serverTestHost = { module = "io.ktor:ktor-server-test-host-jvm", version.ref = "ktor" }


### PR DESCRIPTION
## Summary
- configure android instrumented test dependencies for Compose UI
- add debug dependency for Compose UI test manifest
- add simple MainActivity instrumented test using Compose test rule

## Testing
- `./gradlew ktlintFormat`
- `./gradlew checkAgentsEnvironment`


------
https://chatgpt.com/codex/tasks/task_e_68c6d090c8488332bbd5b6ea1c62f09a