### PR TITLE
Add Android launch instrumentation test

### DIFF
--- a/composeApp/build.gradle.kts
+++ b/composeApp/build.gradle.kts
@@ -97,6 +97,11 @@ kotlin {
 			implementation(libs.logback)
 			implementation(libs.mokkery.runtime)
 		}
+		androidInstrumentedTest.dependencies {
+			implementation(libs.androidx.test.core)
+			implementation(libs.androidx.test.ext.junit)
+			implementation(libs.androidx.test.runner)
+		}
 	}
 }
 
@@ -122,6 +127,7 @@ android {
 		targetSdk = libs.versions.android.targetSdk.get().toInt()
 		versionCode = 1
 		versionName = "1.0"
+		testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
 	}
 	packaging {
 		resources {

--- a/composeApp/src/androidInstrumentedTest/kotlin/de/lehrbaum/voiry/MainActivityStartTest.kt
+++ b/composeApp/src/androidInstrumentedTest/kotlin/de/lehrbaum/voiry/MainActivityStartTest.kt
@@ -1,0 +1,14 @@
+package de.lehrbaum.voiry
+
+import androidx.test.core.app.ActivityScenario
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+class MainActivityStartTest {
+	@Test
+	fun appLaunches() {
+		ActivityScenario.launch(MainActivity::class.java).use { }
+	}
+}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -5,6 +5,9 @@ android-minSdk = "24"
 android-targetSdk = "36"
 androidx-activity = "1.10.1"
 androidx-lifecycle = "2.9.3"
+androidx-test-core = "1.6.1"
+androidx-test-ext-junit = "1.2.1"
+androidx-test-runner = "1.6.1"
 composeHotReload = "1.0.0-beta07"
 composeMultiplatform = "1.8.2"
 junit = "4.13.2"
@@ -33,6 +36,9 @@ junit = { module = "junit:junit", version.ref = "junit" }
 androidx-activity-compose = { module = "androidx.activity:activity-compose", version.ref = "androidx-activity" }
 androidx-lifecycle-viewmodelCompose = { module = "org.jetbrains.androidx.lifecycle:lifecycle-viewmodel-compose", version.ref = "androidx-lifecycle" }
 androidx-lifecycle-runtimeCompose = { module = "org.jetbrains.androidx.lifecycle:lifecycle-runtime-compose", version.ref = "androidx-lifecycle" }
+androidx-test-core = { module = "androidx.test:core", version.ref = "androidx-test-core" }
+androidx-test-ext-junit = { module = "androidx.test.ext:junit", version.ref = "androidx-test-ext-junit" }
+androidx-test-runner = { module = "androidx.test:runner", version.ref = "androidx-test-runner" }
 kotlinx-coroutinesSwing = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-swing", version.ref = "kotlinx-coroutines" }
 kotlinx-coroutinesCore = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-core", version.ref = "kotlinx-coroutines" }
 kotlinx-coroutinesTest = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-test", version.ref = "kotlinx-coroutines" }


### PR DESCRIPTION
## Summary
- add instrumentation test to ensure `MainActivity` launches on Android
- configure Android test dependencies and test runner

## Testing
- `./gradlew ktlintFormat`
- `./gradlew checkAgentsEnvironment`


------
https://chatgpt.com/codex/tasks/task_e_68c6ee2752d083329c3170c4fc42e942