### PR TITLE
Improve recording date selection and add UI test

### DIFF
--- a/composeApp/src/commonMain/kotlin/de/lehrbaum/voiry/ui/MainScreen.kt
+++ b/composeApp/src/commonMain/kotlin/de/lehrbaum/voiry/ui/MainScreen.kt
@@ -12,24 +12,32 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.DatePicker
+import androidx.compose.material3.DatePickerDialog
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.ExtendedFloatingActionButton
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.ListItem
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedButton
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.material3.TextField
+import androidx.compose.material3.TimePicker
 import androidx.compose.material3.TopAppBar
+import androidx.compose.material3.rememberDatePickerState
+import androidx.compose.material3.rememberTimePickerState
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.lifecycle.viewmodel.compose.viewModel
@@ -39,6 +47,12 @@ import de.lehrbaum.voiry.audio.Transcriber
 import de.lehrbaum.voiry.audio.platformRecorder
 import kotlin.time.ExperimentalTime
 import kotlin.uuid.ExperimentalUuidApi
+import kotlinx.datetime.LocalDate
+import kotlinx.datetime.LocalTime
+import kotlinx.datetime.TimeZone
+import kotlinx.datetime.format
+import kotlinx.datetime.format.char
+import kotlinx.datetime.toLocalDateTime
 
 @OptIn(ExperimentalMaterial3Api::class, ExperimentalTime::class, ExperimentalUuidApi::class)
 @Composable
@@ -128,16 +142,49 @@ fun MainScreen(
 		}
 	}
 
+	var showDatePicker by remember { mutableStateOf(false) }
+	var showTimePicker by remember { mutableStateOf(false) }
+	LaunchedEffect(state.pendingRecording) {
+		if (state.pendingRecording == null) {
+			showDatePicker = false
+			showTimePicker = false
+		}
+	}
+	val timeZone = remember { TimeZone.currentSystemDefault() }
+
 	if (state.pendingRecording != null) {
+		val localDateTime = state.pendingRecordedAt.toLocalDateTime(timeZone)
+		val dateText = localDateTime.date.format(DATE_FORMAT)
+		val timeText = localDateTime.time.format(TIME_FORMAT)
+
 		AlertDialog(
 			onDismissRequest = { viewModel.cancelSaveRecording() },
 			title = { Text("Save Recording") },
 			text = {
-				TextField(
-					value = state.pendingTitle,
-					onValueChange = viewModel::updatePendingTitle,
-					label = { Text("Title") },
-				)
+				Column(verticalArrangement = Arrangement.spacedBy(12.dp)) {
+					TextField(
+						value = state.pendingTitle,
+						onValueChange = viewModel::updatePendingTitle,
+						label = { Text("Title") },
+					)
+					Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
+						Text("Recorded on")
+						Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+							OutlinedButton(
+								modifier = Modifier.testTag("saveRecordingDateButton"),
+								onClick = { showDatePicker = true },
+							) {
+								Text(dateText)
+							}
+							OutlinedButton(
+								modifier = Modifier.testTag("saveRecordingTimeButton"),
+								onClick = { showTimePicker = true },
+							) {
+								Text(timeText)
+							}
+						}
+					}
+				}
 			},
 			confirmButton = {
 				TextButton(
@@ -149,6 +196,66 @@ fun MainScreen(
 				TextButton(onClick = { viewModel.cancelSaveRecording() }) { Text("Cancel") }
 			},
 		)
+
+		if (showDatePicker) {
+			val datePickerState = rememberDatePickerState(
+				initialSelectedDateMillis = state.pendingRecordedAt.toEpochMilliseconds(),
+			)
+			DatePickerDialog(
+				onDismissRequest = { showDatePicker = false },
+				confirmButton = {
+					TextButton(
+						onClick = {
+							val selectedDateMillis = datePickerState.selectedDateMillis
+							if (selectedDateMillis != null) {
+								viewModel.updatePendingRecordedDate(selectedDateMillis)
+								showDatePicker = false
+							}
+						},
+						enabled = datePickerState.selectedDateMillis != null,
+					) { Text("OK") }
+				},
+				dismissButton = {
+					TextButton(onClick = { showDatePicker = false }) { Text("Cancel") }
+				},
+			) {
+				DatePicker(state = datePickerState)
+			}
+		}
+
+		if (showTimePicker) {
+			val timePickerState = rememberTimePickerState(
+				initialHour = localDateTime.hour,
+				initialMinute = localDateTime.minute,
+				is24Hour = true,
+			)
+			LaunchedEffect(state.pendingRecordedAt, showTimePicker) {
+				if (showTimePicker) {
+					val updated = state.pendingRecordedAt.toLocalDateTime(timeZone)
+					timePickerState.hour = updated.hour
+					timePickerState.minute = updated.minute
+				}
+			}
+			AlertDialog(
+				onDismissRequest = { showTimePicker = false },
+				title = { Text("Select time") },
+				text = { TimePicker(state = timePickerState) },
+				confirmButton = {
+					TextButton(
+						onClick = {
+							viewModel.updatePendingRecordedTime(
+								timePickerState.hour,
+								timePickerState.minute,
+							)
+							showTimePicker = false
+						},
+					) { Text("OK") }
+				},
+				dismissButton = {
+					TextButton(onClick = { showTimePicker = false }) { Text("Cancel") }
+				},
+			)
+		}
 	}
 }
 
@@ -171,7 +278,10 @@ private fun EntryRow(
 			Text(entry.transcriptionText ?: entry.transcriptionStatus.displayName())
 		},
 		trailingContent = {
-			Row(horizontalArrangement = Arrangement.spacedBy(8.dp), verticalAlignment = Alignment.CenterVertically) {
+			Row(
+				horizontalArrangement = Arrangement.spacedBy(8.dp),
+				verticalAlignment = Alignment.CenterVertically,
+			) {
 				TranscribeButtonWithProgress(
 					transcriber = transcriber,
 					onTranscribe = onTranscribeClick,
@@ -216,4 +326,11 @@ private fun InfoBanner(
 			}
 		}
 	}
+}
+
+private val DATE_FORMAT = LocalDate.Format { date(LocalDate.Formats.ISO) }
+private val TIME_FORMAT = LocalTime.Format {
+	hour()
+	char(':')
+	minute()
 }

--- a/composeApp/src/jvmTest/kotlin/de/lehrbaum/voiry/ui/MainScreenTest.kt
+++ b/composeApp/src/jvmTest/kotlin/de/lehrbaum/voiry/ui/MainScreenTest.kt
@@ -7,6 +7,7 @@ import androidx.compose.ui.test.assertCountEquals
 import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.hasText
 import androidx.compose.ui.test.onAllNodesWithText
+import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick
 import androidx.compose.ui.test.performTextInput
@@ -31,6 +32,7 @@ import dev.mokkery.every
 import dev.mokkery.everySuspend
 import dev.mokkery.matcher.any
 import dev.mokkery.mock
+import kotlin.test.assertEquals
 import kotlin.time.Clock
 import kotlin.time.Duration
 import kotlin.time.ExperimentalTime
@@ -39,6 +41,10 @@ import kotlin.uuid.Uuid
 import kotlinx.collections.immutable.PersistentList
 import kotlinx.collections.immutable.toPersistentList
 import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.datetime.LocalDate
+import kotlinx.datetime.TimeZone
+import kotlinx.datetime.format
+import kotlinx.datetime.toLocalDateTime
 import kotlinx.io.Buffer
 import kotlinx.io.writeString
 import org.junit.Test
@@ -208,6 +214,63 @@ class MainScreenTest {
 		}
 
 	@Test
+	fun changing_recording_date_updates_saved_entry() =
+		runComposeUiTest {
+			val timeZone = TimeZone.currentSystemDefault()
+			val dateFormat = LocalDate.Format { date(LocalDate.Formats.ISO) }
+			var savedEntry: VoiceDiaryEntry? = null
+			val clientMock = diaryClientMock(onCreateEntry = { savedEntry = it })
+			val client = clientMock.client
+			val buffer = Buffer().apply { writeString("new bytes") }
+			val recorder = mock<Recorder>()
+			every { recorder.isAvailable } returns true
+			every { recorder.startRecording() } returns Unit
+			every { recorder.stopRecording() } returns Result.success(buffer)
+
+			setContent {
+				CompositionLocalProvider(
+					LocalLifecycleOwner provides FakeLifecycleOwner(),
+					LocalViewModelStoreOwner provides FakeViewModelStoreOwner(),
+				) {
+					MaterialTheme {
+						MainScreen(
+							diaryClient = client,
+							recorder = recorder,
+							transcriber = null,
+							onEntryClick = { },
+						)
+					}
+				}
+			}
+
+			onNodeWithText("Record").performClick()
+			waitUntilAtLeastOneExists(hasText("Stop"))
+
+			onNodeWithText("Stop").performClick()
+			waitUntilAtLeastOneExists(hasText("Title"))
+
+			val initialDate = Clock.System.now().toLocalDateTime(timeZone).date
+			val desiredDay = if (initialDate.day != 15) 15 else 16
+			val desiredDate = LocalDate(initialDate.year, initialDate.month, desiredDay)
+			val desiredDateText = desiredDate.format(dateFormat)
+
+			onNodeWithTag("saveRecordingDateButton").performClick()
+			waitUntilAtLeastOneExists(hasText("OK"))
+
+			onAllNodesWithText(desiredDay.toString(), useUnmergedTree = true)[0].performClick()
+			onNodeWithText("OK").performClick()
+
+			waitUntilAtLeastOneExists(hasText(desiredDateText))
+
+			onNodeWithText("Title").performTextInput("Backdated entry")
+			onNodeWithText("Save").performClick()
+
+			waitUntilAtLeastOneExists(hasText("Backdated entry"))
+			val savedDate = checkNotNull(savedEntry).recordedAt.toLocalDateTime(timeZone).date
+			assertEquals(desiredDate, savedDate)
+		}
+
+	@Test
 	fun delete_removes_item_from_list() =
 		runComposeUiTest {
 			val clientMock = diaryClientMock()
@@ -301,6 +364,7 @@ private fun diaryClientMock(
 		)
 	}.toPersistentList(),
 	connectionErrors: List<String> = emptyList(),
+	onCreateEntry: ((VoiceDiaryEntry) -> Unit)? = null,
 ): DiaryClientMock {
 	val pendingErrors = ArrayDeque(connectionErrors)
 	val connectionErrorFlow = MutableStateFlow(pendingErrors.removeFirstOrNull())
@@ -309,6 +373,7 @@ private fun diaryClientMock(
 		every { entries } returns entriesFlow
 		every { connectionError } returns connectionErrorFlow
 		everySuspend { createEntry(any(), any()) } calls { (entry: VoiceDiaryEntry, _: ByteArray) ->
+			onCreateEntry?.invoke(entry)
 			val withTranscript = entry.copy(
 				transcriptionText = "Transcript for ${entry.title}",
 				transcriptionStatus = TranscriptionStatus.DONE,


### PR DESCRIPTION
## Summary
- move the save-recording dialog's date/time adjustments into MainViewModel and expose helpers for updating the stored instant
- mark the dialog buttons with test tags so they can be addressed from Compose UI tests
- add a MainScreen UI test that backdates a recording and asserts the saved entry uses the selected day

## Testing
- ./gradlew ktlintFormat --console=plain
- ./gradlew checkAgentsEnvironment --console=plain

------
https://chatgpt.com/codex/tasks/task_e_68d1a51b99f48332b962fdf8e2e7e0c8